### PR TITLE
fix: Media-Liste category_id=0 Filter + mediaIsInUse 500er absichern

### DIFF
--- a/lib/RoutePackage/Media.php
+++ b/lib/RoutePackage/Media.php
@@ -506,13 +506,16 @@ class Media extends RoutePackage
         $SqlQueryWhere = [];
         $SqlParameters = [];
 
-        if (null !== $Query['filter']['category_id'] && 0 < $Query['filter']['category_id']) {
-            $MediaCategory = rex_media_category::get($Query['filter']['category_id']);
-            if (!$MediaCategory) {
-                return new Response(json_encode(['error' => 'Category not found']), 404);
+        if (null !== $Query['filter']['category_id']) {
+            $categoryId = (int) $Query['filter']['category_id'];
+            if ($categoryId > 0) {
+                $MediaCategory = rex_media_category::get($categoryId);
+                if (!$MediaCategory) {
+                    return new Response(json_encode(['error' => 'Category not found']), 404);
+                }
             }
             $SqlQueryWhere[':category_id'] = 'category_id = :category_id';
-            $SqlParameters[':category_id'] = $Query['filter']['category_id'];
+            $SqlParameters[':category_id'] = $categoryId;
         }
 
         if (null !== $Query['filter']['title'] && '' != $Query['filter']['title']) {

--- a/lib/RoutePackage/Media.php
+++ b/lib/RoutePackage/Media.php
@@ -635,6 +635,12 @@ class Media extends RoutePackage
             return $permResponse;
         }
 
+        try {
+            $isInUse = false !== rex_mediapool::mediaIsInUse($Parameter['filename']);
+        } catch (\Throwable $e) {
+            $isInUse = false;
+        }
+
         $Return = [
             'id' => $Media->getId(),
             'category_id' => $Media->getCategoryId(),
@@ -649,7 +655,7 @@ class Media extends RoutePackage
             'createuser' => $Media->getCreateUser(),
             'updatedate' => $Media->getUpdateDate(),
             'updateuser' => $Media->getUpdateUser(),
-            'is_in_use' => (false !== rex_mediapool::mediaIsInUse($Parameter['filename']) ? true : false),
+            'is_in_use' => $isInUse,
             'is_image' => $Media->isImage(),
             'file_exists' => $Media->fileExists(),
         ];


### PR DESCRIPTION
## Fixes

### 1. Media-Liste `filter[category_id]=0` wird jetzt korrekt verarbeitet

**Problem:** Beim Filtern mit `filter[category_id]=0` (Root-Kategorie) wurde der Filter ignoriert und **alle Medien** zurückgegeben.

**Ursache:** Die Bedingung `0 < $Query["filter"]["category_id"]` war für `category_id=0` immer `false`.

**Fix:**
- `category_id=0` wird jetzt als SQL WHERE-Bedingung gesetzt
- `rex_media_category::get()` wird nur für `id > 0` geprüft (Root hat keine Kategorie-Instanz)
- Expliziter Cast auf `(int)` für Type Safety

### 2. `handleGetMedia()`: mediaIsInUse() in try-catch wrappen

**Problem:** `rex_mediapool::mediaIsInUse()` ruft den Extension Point `MEDIA_IS_IN_USE` auf. Fehlerhafte EP-Listener (z.B. `$ep->setSubject(true)` statt Array) können einen `TypeError` auslösen und die API mit HTTP 500 crashen lassen.

**Konkreter Fall:** `mediapool_tools` setzte `$ep->setSubject(true)` statt das Warning-Array korrekt weiterzugeben. Das führte in `mediapool.php` Zeile 100 zu `implode("", true)` → TypeError.

**Fix:**
- `mediaIsInUse()` wird in `try/catch(\Throwable)` gewrapped
- Bei Fehler: `is_in_use: false` als sicherer Fallback
- Eine REST-API sollte nie wegen fehlerhafter Drittanbieter-EP-Listener mit 500 crashen
