### PR TITLE
Fix Article-List, Trailing-Slash und Error-Handling

### DIFF
--- a/lib/RouteCollection.php
+++ b/lib/RouteCollection.php
@@ -5,13 +5,17 @@ namespace FriendsOfRedaxo\Api;
 use Exception;
 use FriendsOfRedaxo\Api\Auth as ApiAuth;
 use rex;
+use rex_logger;
 use rex_response;
 use rex_type;
 use rex_user;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
+use Throwable;
 
 use function count;
 use function is_array;
@@ -118,23 +122,45 @@ class RouteCollection
             $context->fromRequest(rex::getRequest());
             $matcher = new UrlMatcher($routes, $context);
 
-            $parameters = $matcher->match(rex::getRequest()->getPathInfo());
+            try {
+                $parameters = $matcher->match(rex::getRequest()->getPathInfo());
+            } catch (ResourceNotFoundException $e) {
+                $Response = new Response(json_encode(['error' => 'Route not found']), 404);
+                $parameters = null;
+            } catch (MethodNotAllowedException $e) {
+                $Response = new Response(json_encode([
+                    'error' => 'Method not allowed',
+                    'allowed' => $e->getAllowedMethods(),
+                ]), 405);
+                $parameters = null;
+            }
 
-            if (!isset($parameters['_controller'])) {
-                $Response = new Response(json_encode(['error' => 'Controller Not found']), 404);
-            } else {
-                $controller = $parameters['_controller'];
-                $AuthObject = $RegisterdRoutes[$parameters['_route']]['authorization'] ?? null;
-
-                // if no AuthObject is set, we assume that the route is public
-                if ($AuthObject && !$AuthObject->isAuthorized($parameters)) {
-                    $Response = new Response(json_encode(['error' => 'Authorization failed']), 401);
+            if (null !== $parameters) {
+                if (!isset($parameters['_controller'])) {
+                    $Response = new Response(json_encode(['error' => 'Controller not found']), 404);
                 } else {
-                    $Response = $controller($parameters, $RegisterdRoutes[$parameters['_route']]);
+                    $controller = $parameters['_controller'];
+                    $AuthObject = $RegisterdRoutes[$parameters['_route']]['authorization'] ?? null;
+
+                    // if no AuthObject is set, we assume that the route is public
+                    if ($AuthObject && !$AuthObject->isAuthorized($parameters)) {
+                        $Response = new Response(json_encode(['error' => 'Authorization failed']), 401);
+                    } else {
+                        try {
+                            $Response = $controller($parameters, $RegisterdRoutes[$parameters['_route']]);
+                        } catch (Throwable $e) {
+                            rex_logger::logException($e);
+                            $Response = new Response(json_encode([
+                                'error' => 'Internal server error',
+                                'message' => $e->getMessage(),
+                            ]), 500);
+                        }
+                    }
                 }
             }
-        } catch (Exception $e) {
-            $Response = new Response(json_encode(['error' => 'Route with method not found or no access']), 401);
+        } catch (Throwable $e) {
+            rex_logger::logException($e);
+            $Response = new Response(json_encode(['error' => 'Internal server error']), 500);
         }
 
         rex_response::setStatus($Response->getStatusCode());

--- a/lib/RoutePackage/Structure.php
+++ b/lib/RoutePackage/Structure.php
@@ -123,7 +123,7 @@ class Structure extends RoutePackage
         RouteCollection::registerRoute(
             'structure/articles/add',
             new Route(
-                'structure/articles/',
+                'structure/articles',
                 [
                     '_controller' => 'FriendsOfRedaxo\Api\RoutePackage\Structure::handleAddArticle',
                     'Body' => [
@@ -167,7 +167,7 @@ class Structure extends RoutePackage
         RouteCollection::registerRoute(
             'structure/categories/add',
             new Route(
-                'structure/categories/',
+                'structure/categories',
                 [
                     '_controller' => 'FriendsOfRedaxo\Api\RoutePackage\Structure::handleAddCategory',
                     'Body' => [
@@ -538,19 +538,16 @@ class Structure extends RoutePackage
             $SqlParameters[':parent_id'] = $Query['filter']['parent_id'];
         }
 
-        if (null !== $Query['filter']['name']) {
-            $SqlQueryWhere[':name'] = 'id LIKE :name';
-            $SqlParameters[':name'] = '%' . $Query['filter']['id'] . '%';
+        if (null !== $Query['filter']['name'] && '' !== $Query['filter']['name']) {
+            $SqlQueryWhere[':name'] = 'name LIKE :name';
+            $SqlParameters[':name'] = '%' . $Query['filter']['name'] . '%';
         }
 
         $ArticeFields = ['id', 'pid', 'name', 'catname', 'catpriority', 'clang_id', 'parent_id', 'priority', 'startarticle', 'status', 'template_id', 'createdate', 'createuser', 'updatedate', 'updateuser', 'revision'];
 
-        $per_page = (1 > $Query['per_page']) ? 10 : $Query['per_page'];
-        $page = (1 > $Query['page']) ? 1 : $Query['page'];
+        $per_page = (1 > $Query['per_page']) ? 10 : (int) $Query['per_page'];
+        $page = (1 > $Query['page']) ? 1 : (int) $Query['page'];
         $start = ($page - 1) * $per_page;
-
-        $SqlParameters[':per_page'] = $per_page;
-        $SqlParameters[':start'] = $start;
 
         $ArticlesSQL = rex_sql::factory();
         $Articles = $ArticlesSQL->getArray(
@@ -561,7 +558,7 @@ class Structure extends RoutePackage
                 ' . rex::getTablePrefix() . 'article
             ' . (count($SqlQueryWhere) ? 'where ' . implode(' and ', $SqlQueryWhere) : '') . '
 
-            LIMIT :start, :per_page
+            LIMIT ' . $start . ', ' . $per_page . '
                 ',
             $SqlParameters,
         );


### PR DESCRIPTION
## Summary

Vier zusammenhängende Fixes rund um den Article-List-Endpoint und das generische Exception-Handling im Routing-Stack:

- **`Structure::handleArticleList` — `name`-Filter**: bisher referenziert `$Query['filter']['id']` (existiert im Filter-Schema gar nicht), matched auf `id LIKE` statt `name LIKE`, und greift wegen `null !== ''`-Vergleich mit dem Default `''` immer. Erzeugt bei jedem List-Call eine PHP-Warning `Undefined array key "id"` und ist als Filter funktional kaputt.
- **`Structure::handleArticleList` — `LIMIT`-Binding**: `:start` und `:per_page` werden via `rex_sql::factory()->getArray($sql, $params)` als String gebunden. Mit strikter PDO-Konfig (Emulation aus) lehnt MySQL `LIMIT 'x','y'` ab, der Endpoint kippt — und der Fehler wird vom äußeren Catch zu einem 401 verschluckt. Werte sind jetzt mit `(int)` direkt im SQL-String.
- **`structure/articles/add` & `structure/categories/add` — trailing slash**: GET-List liegt auf `'structure/articles'`, POST-Add bisher auf `'structure/articles/'` — der Matcher braucht die exakte Form. Die anderen Resources (`templates`, `modules`) machen es richtig: gleiche Pfade, unterscheidung per Methode. Diese beiden Routes werden hier angeglichen. **Breaking** für Clients, die bisher den trailing slash mitschickten.
- **`RouteCollection::handle()` — Exception-Handling**: bisher fällt **alles** in einen einzigen `catch (Exception)` mit 401 `Route with method not found or no access` — egal ob Matcher kein Route findet, die Methode nicht passt, der Controller wirft, oder ein SQL-Fehler in einem Handler aufschlägt. Diagnose über die Response ist dadurch nicht möglich. Jetzt:
  - `ResourceNotFoundException` → **404** `Route not found`
  - `MethodNotAllowedException` → **405** `Method not allowed`, mit `allowed`-Liste im Body
  - `Throwable` aus dem Controller → **500** mit `rex_logger::logException`
  - äußere `Throwable` ebenfalls **500** mit Logging
  - Auth-Fehler bleibt unverändert **401**

## Test plan

- [x] `php -l` clean auf beiden Files
- [x] Lokal verifiziert (REDAXO 5.17, lokales `api`-AddOn auf gleichem v1.1-Stand wie Upstream-`main`):
    - `GET /api/structure/articles?filter[name]=Aus` → 200, filtert korrekt; keine `Undefined array key`-Warning mehr
    - `POST /api/structure/articles` (ohne Slash) → 201
    - `POST /api/structure/articles/` (mit Slash) → 404 `Route not found` (bewusst breaking)
    - `GET /api/does-not-exist` → 404 `Route not found` (vorher 401)
    - `PUT /api/structure/articles` → 405 `Method not allowed` mit `allowed: ["GET","POST"]`
    - SQL-Fehler im Handler werden jetzt mit Stacktrace im Logfile sichtbar (`rex_logger`), Response 500
- [ ] Existierende Clients, die `POST /api/structure/articles/` mit trailing slash aufrufen, müssen umgestellt werden — Hinweis im Changelog/Release Notes nötig.
- [ ] Optional als Folge-PR: gleiche Trailing-Slash-Bereinigung in der README-Endpunkt-Tabelle und im OpenAPI-Output prüfen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)