### PR TITLE
Fix article and category status endpoints

### DIFF
--- a/lib/RoutePackage/Structure.php
+++ b/lib/RoutePackage/Structure.php
@@ -671,6 +671,14 @@ class Structure extends RoutePackage
                 return new JsonResponse(['error' => 'Article not created - reason unknown'], 500);
             }
 
+            // rex_article_service::addArticle() ignores $data['status'] and hardcodes
+            // status=0 in REDAXO core — apply the requested status explicitly per clang.
+            if (1 === (int) $Data['status']) {
+                foreach (rex_clang::getAllIds() as $clangId) {
+                    rex_article_service::articleStatus($ArticleId, $clangId, 1);
+                }
+            }
+
             return new JsonResponse([
                 'message' => 'Article created',
                 'id' => $ArticleId,
@@ -1042,7 +1050,7 @@ class Structure extends RoutePackage
             if (null !== $Data['status']) {
                 $currentStatus = $Article->isOnline() ? 1 : 0;
                 if ($currentStatus !== $Data['status']) {
-                    rex_article_service::changeStatus($Parameter['id'], $Article->getClangId(), $Data['status']);
+                    rex_article_service::articleStatus($Parameter['id'], $Article->getClangId(), $Data['status']);
                 }
             }
 
@@ -1101,7 +1109,7 @@ class Structure extends RoutePackage
             if (null !== $Data['status']) {
                 $currentStatus = $Category->isOnline() ? 1 : 0;
                 if ($currentStatus !== $Data['status']) {
-                    rex_category_service::changeStatus($Parameter['id'], $Category->getClangId(), $Data['status']);
+                    rex_category_service::categoryStatus($Parameter['id'], $Category->getClangId(), $Data['status']);
                 }
             }
 

--- a/tests/StructureApiTest.php
+++ b/tests/StructureApiTest.php
@@ -131,6 +131,30 @@ class StructureApiTest extends ApiTestCase
         $this->assertError($response);
     }
 
+    public function testCreateArticleWithStatusOnline(): void
+    {
+        // Regression: rex_article_service::addArticle() ignores $data['status']
+        // and hardcodes status=0 in REDAXO core. The api addon must explicitly
+        // promote the article to status=1 after creation.
+        $name = $this->generateTestName('article_online');
+        $categoryId = self::$config['test_data']['existing_category_id'];
+
+        $createResponse = $this->post('structure/articles', [
+            'name' => $name,
+            'category_id' => $categoryId,
+            'priority' => 1,
+            'status' => 1,
+        ]);
+
+        $this->assertStatus(201, $createResponse);
+        $articleId = $createResponse['data']['id'];
+        $this->trackResource('structure/articles', $articleId);
+
+        $getResponse = $this->get('structure/articles/' . $articleId);
+        $this->assertSuccess($getResponse);
+        $this->assertSame(1, $getResponse['data']['status'], 'Article should be online when created with status=1');
+    }
+
     public function testUpdateArticle(): void
     {
         // Erst Artikel erstellen
@@ -154,6 +178,34 @@ class StructureApiTest extends ApiTestCase
 
         $this->assertSuccess($updateResponse);
         $this->assertHasField($updateResponse, 'message');
+    }
+
+    public function testUpdateArticleStatus(): void
+    {
+        // Regression: handleUpdateArticle previously called the non-existent
+        // rex_article_service::changeStatus() (correct name: articleStatus).
+        // PUT with {status:1} on an offline article must turn it online.
+        $name = $this->generateTestName('article_status');
+        $createResponse = $this->post('structure/articles', [
+            'name' => $name,
+            'category_id' => 0,
+            'priority' => 1,
+            'status' => 0,
+        ]);
+        $this->assertStatus(201, $createResponse);
+        $articleId = $createResponse['data']['id'];
+        $this->trackResource('structure/articles', $articleId);
+
+        $updateResponse = $this->put('structure/articles/' . $articleId, ['status' => 1]);
+        $this->assertSuccess($updateResponse);
+
+        $getResponse = $this->get('structure/articles/' . $articleId);
+        $this->assertSame(1, $getResponse['data']['status'], 'Article must be online after PUT status=1');
+
+        // Flip back to offline as a second regression check.
+        $this->put('structure/articles/' . $articleId, ['status' => 0]);
+        $getResponse = $this->get('structure/articles/' . $articleId);
+        $this->assertSame(0, $getResponse['data']['status'], 'Article must be offline after PUT status=0');
     }
 
     public function testDeleteArticle(): void
@@ -217,6 +269,24 @@ class StructureApiTest extends ApiTestCase
             'name' => $newName,
         ]);
 
+        $this->assertSuccess($updateResponse);
+    }
+
+    public function testUpdateCategoryStatus(): void
+    {
+        // Regression: handleUpdateCategory previously called the non-existent
+        // rex_category_service::changeStatus() (correct name: categoryStatus).
+        $name = $this->generateTestName('category_status');
+        $createResponse = $this->post('structure/categories', [
+            'name' => $name,
+            'category_id' => 0,
+            'status' => 1,
+        ]);
+        $this->assertStatus(201, $createResponse);
+        $categoryId = $createResponse['data']['id'];
+        $this->trackResource('structure/categories', $categoryId);
+
+        $updateResponse = $this->put('structure/categories/' . $categoryId, ['status' => 0]);
         $this->assertSuccess($updateResponse);
     }
 


### PR DESCRIPTION
## Summary

Three related bugs in `lib/RoutePackage/Structure.php` prevented the `status` field from working end-to-end. All three are now covered by regression tests in `tests/StructureApiTest.php`.

## The bugs

### 1. `POST /api/structure/articles` ignored the `status` payload field

`rex_article_service::addArticle()` in REDAXO core accepts a `status` parameter but never persists it — `redaxo/src/addons/structure/lib/service_article.php` hardcodes `\$AART->setValue('status', 0);` on line 84. Articles created via the REST API always came back offline regardless of what was sent in the body.

**Fix:** call `rex_article_service::articleStatus()` per clang after `addArticle()` when `status=1` was requested (categories are unaffected — `addCategory()` honors `\$data['status']` correctly).

### 2. `PUT /api/structure/articles/{id}` with `{\"status\":N}` crashed with 500

`handleUpdateArticle` called `rex_article_service::changeStatus()`, which does not exist. The correct method name in REDAXO core is `articleStatus()`. Symptom: `\"Call to undefined method rex_article_service::changeStatus()\"`.

### 3. `PUT /api/structure/categories/{id}` with `{\"status\":N}` had the symmetric bug

`handleUpdateCategory` called `rex_category_service::changeStatus()` (correct name: `categoryStatus()`). Same symptom.

## Verified end-to-end

Against a live REDAXO 5.17 + this api addon installation:

| Scenario | Before | After |
|---|---|---|
| POST `/articles` with `status:1` | DB row has `status=0` | DB row has `status=1` ✅ |
| POST `/articles` `status:0`, then PUT `status:1` | HTTP 500 | HTTP 200, article online ✅ |
| POST `/categories` `status:1`, then PUT `status:0` | HTTP 500 | HTTP 200, category offline in active clang ✅ |

The three new regression tests in `tests/StructureApiTest.php` exercise exactly these flows.

## How I found these

Was building a `redaxo-ycom` quickstart skill for the [FriendsOfREDAXO claude-marketplace](https://github.com/FriendsOfREDAXO/claude-marketplace) — a recipe to bootstrap a YCom community frontend on an instance with the api addon installed. Fresh articles needed to be online to be reachable, and the workaround in the skill is currently \`rex_article_service::articleStatus()\` from a small PHP companion — but that's a workaround that should not be necessary. With this PR, the api addon does the right thing on its own.

## Test plan

- [x] `testCreateArticle` (existing, status=0) still passes
- [x] `testCreateArticleWithStatusOnline` (new) — POST status=1, GET back, assert status=1
- [x] `testUpdateArticleStatus` (new) — toggle 0→1→0 via PUT
- [x] `testUpdateCategoryStatus` (new) — toggle 1→0 via PUT
- [x] Existing `testUpdateArticle` / `testUpdateCategory` (no status field) unaffected
- [ ] Reviewer sanity check

🤖 Generated with [Claude Code](https://claude.com/claude-code)