### PR TITLE
feat(structure): slice priority on add + new /move endpoint

### DIFF
--- a/lib/RoutePackage/Structure.php
+++ b/lib/RoutePackage/Structure.php
@@ -428,6 +428,11 @@ class Structure extends RoutePackage
                                 'required' => true,
                                 'default' => null,
                             ],
+                            'priority' => [
+                                'type' => 'int',
+                                'required' => false,
+                                'default' => null,
+                            ],
                         ],
                         $Values, // value1...19
                         $Medias, // media1...10
@@ -910,6 +915,14 @@ class Structure extends RoutePackage
                 $SliceData['link' . $i] = $Data['link' . $i];
                 $SliceData['linklist' . $i] = $Data['linklist' . $i];
             }
+        }
+
+        // Optional priority: rex_content_service::addSlice() accepts a `priority` key in $data
+        // (content_service.php:17-24). If omitted, the service appends at the end (MAX(priority)+1).
+        // priority <= 0 is normalised to 1 by the service. After insert the service calls
+        // rex_sql_util::organizePriorities() to renormalise the sequence.
+        if (null !== $Data['priority']) {
+            $SliceData['priority'] = (int) $Data['priority'];
         }
 
         try {

--- a/lib/RoutePackage/Structure.php
+++ b/lib/RoutePackage/Structure.php
@@ -8,6 +8,7 @@ use FriendsOfRedaxo\Api\ListHelper;
 use FriendsOfRedaxo\Api\RouteCollection;
 use FriendsOfRedaxo\Api\RoutePackage;
 use rex;
+use rex_api_exception;
 use rex_article;
 use rex_article_cache;
 use rex_article_service;
@@ -526,6 +527,34 @@ class Structure extends RoutePackage
                 [],
                 ['DELETE']),
             'Delete a slice of an article',
+            null,
+            new BearerAuth()
+        );
+
+        // Slice eines Artikels verschieben (moveup/movedown) ✅
+        RouteCollection::registerRoute(
+            'structure/articles/slices/move',
+            new Route(
+                'structure/articles/{id}/slices/{slice_id}/move',
+                [
+                    '_controller' => 'FriendsOfRedaxo\Api\RoutePackage\Structure::handleMoveArticleSlice',
+                    'Body' => [
+                        'direction' => [
+                            'type' => 'string',
+                            'required' => true,
+                            'default' => null,
+                        ],
+                    ],
+                ],
+                [
+                    'id' => '\d+',
+                    'slice_id' => '\d+',
+                ],
+                [],
+                '',
+                [],
+                ['POST']),
+            'Move a slice up or down within its ctype',
             null,
             new BearerAuth()
         );
@@ -1434,6 +1463,87 @@ class Structure extends RoutePackage
         } catch (Exception $e) {
             return new JsonResponse(['error' => $e->getMessage()], 500);
         }
+    }
+
+    /** @api */
+    public static function handleMoveArticleSlice($Parameter, array $Route = []): Response
+    {
+        $Data = json_decode(rex::getRequest()->getContent(), true);
+
+        if (!is_array($Data)) {
+            return new JsonResponse(['error' => 'Invalid input'], 400);
+        }
+
+        try {
+            $Data = RouteCollection::getQuerySet($Data, $Parameter['Body']);
+        } catch (Exception $e) {
+            return new JsonResponse(['error' => 'Body field: `' . $e->getMessage() . '` is required'], 400);
+        }
+
+        $direction = $Data['direction'];
+        if ('moveup' !== $direction && 'movedown' !== $direction) {
+            return new JsonResponse([
+                'error' => 'Invalid direction',
+                'direction' => rex_escape((string) $direction),
+                'allowed' => ['moveup', 'movedown'],
+            ], 400);
+        }
+
+        $sliceId = (int) $Parameter['slice_id'];
+        $articleId = (int) $Parameter['id'];
+
+        $Slice = self::loadSliceForArticle($sliceId, $articleId);
+        if (null === $Slice) {
+            return new JsonResponse(['error' => 'Slice not found'], 404);
+        }
+
+        $clangId = (int) $Slice['clang_id'];
+        $moduleId = (int) $Slice['module_id'];
+
+        $Article = rex_article::get($articleId, $clangId);
+        if (!$Article) {
+            return new JsonResponse(['error' => 'Article not found'], 404);
+        }
+
+        // Permission cascade mirrors rex_api_content_move_slice::execute()
+        // (addons/structure/plugins/content/lib/api_functions/api_content.php:29-50).
+        // For Bearer token calls (`$user === null`), scope grants access.
+        $user = RouteCollection::getBackendUser($Route);
+        if (null !== $user && !$user->isAdmin() && !$user->hasPerm('moveSlice[]')) {
+            return new JsonResponse(['error' => 'Permission denied'], 403);
+        }
+        $permResponse = self::checkStructurePerm($user, $Article->getCategoryId());
+        if (null !== $permResponse) {
+            return $permResponse;
+        }
+        if (null !== $user && !$user->getComplexPerm('modules')->hasPerm($moduleId)) {
+            return new JsonResponse(['error' => 'Permission denied'], 403);
+        }
+
+        try {
+            // rex_content_service::moveSlice() handles everything: fires SLICE_MOVE, swaps the
+            // priority, calls rex_sql_util::organizePriorities(), invalidates the content cache
+            // via rex_article_cache::deleteContent(), and fires art_content_updated.
+            // We mirror api_content.php exactly — no extra EPs, no extra cache calls.
+            $message = rex_content_service::moveSlice($sliceId, $clangId, $direction);
+        } catch (rex_api_exception $e) {
+            // moveSlice throws when the slice is already at the boundary (top can't moveup, etc.)
+            // — surface as 422 rather than 500 since the request was structurally valid but the
+            // requested state transition is not possible.
+            return new JsonResponse([
+                'error' => $e->getMessage(),
+                'slice_id' => $sliceId,
+                'direction' => $direction,
+            ], 422);
+        } catch (Exception $e) {
+            return new JsonResponse(['error' => $e->getMessage()], 500);
+        }
+
+        return new JsonResponse([
+            'message' => $message,
+            'slice_id' => $sliceId,
+            'direction' => $direction,
+        ], 200);
     }
 
     /**

--- a/tests/BackendApiTest.php
+++ b/tests/BackendApiTest.php
@@ -759,6 +759,90 @@ class BackendApiTest extends TestCase
         }
     }
 
+    public function testAdminCreateArticleSliceAtTop(): void
+    {
+        $articleId = self::$config['test_data']['existing_article_id'];
+        $moduleId = self::$config['test_data']['existing_module_id'];
+        $clangId = self::$config['test_data']['existing_clang_id'];
+
+        $createResponse = $this->adminPost('structure/articles/' . $articleId . '/slices', [
+            'module_id' => $moduleId,
+            'clang_id' => $clangId,
+            'ctype_id' => 1,
+            'priority' => 1,
+            'value1' => 'BACKEND_TEST_top_' . uniqid(),
+        ]);
+        if (201 !== $createResponse['status']) {
+            $this->markTestSkipped('Slice konnte nicht angelegt werden (Template/Modul-Zuordnung fehlt).');
+        }
+        $sliceId = (int) $createResponse['data']['slice_id'];
+
+        try {
+            $getResponse = $this->adminGet('structure/articles/' . $articleId . '/slices/' . $sliceId);
+            $this->assertSame(200, $getResponse['status']);
+            $this->assertSame(1, (int) $getResponse['data']['priority']);
+        } finally {
+            $this->adminDelete('structure/articles/' . $articleId . '/slices/' . $sliceId);
+        }
+    }
+
+    public function testAdminMoveArticleSlice(): void
+    {
+        $articleId = self::$config['test_data']['existing_article_id'];
+        $moduleId = self::$config['test_data']['existing_module_id'];
+        $clangId = self::$config['test_data']['existing_clang_id'];
+
+        $first = $this->adminPost('structure/articles/' . $articleId . '/slices', [
+            'module_id' => $moduleId, 'clang_id' => $clangId, 'ctype_id' => 1,
+            'priority' => 1, 'value1' => 'BACKEND_TEST_first_' . uniqid(),
+        ]);
+        if (201 !== $first['status']) {
+            $this->markTestSkipped('Slice konnte nicht angelegt werden.');
+        }
+        $firstId = (int) $first['data']['slice_id'];
+
+        $second = $this->adminPost('structure/articles/' . $articleId . '/slices', [
+            'module_id' => $moduleId, 'clang_id' => $clangId, 'ctype_id' => 1,
+            'priority' => 2, 'value1' => 'BACKEND_TEST_second_' . uniqid(),
+        ]);
+        $this->assertSame(201, $second['status']);
+        $secondId = (int) $second['data']['slice_id'];
+
+        try {
+            $moveResponse = $this->adminPost(
+                'structure/articles/' . $articleId . '/slices/' . $secondId . '/move',
+                ['direction' => 'moveup'],
+            );
+            $this->assertSame(200, $moveResponse['status']);
+
+            $getSecond = $this->adminGet('structure/articles/' . $articleId . '/slices/' . $secondId);
+            $getFirst = $this->adminGet('structure/articles/' . $articleId . '/slices/' . $firstId);
+            $this->assertLessThan(
+                (int) $getFirst['data']['priority'],
+                (int) $getSecond['data']['priority'],
+                'After moveup the second slice should now have a lower priority than the first',
+            );
+        } finally {
+            $this->adminDelete('structure/articles/' . $articleId . '/slices/' . $secondId);
+            $this->adminDelete('structure/articles/' . $articleId . '/slices/' . $firstId);
+        }
+    }
+
+    public function testRestrictedUserCannotMoveArticleSlice(): void
+    {
+        $articleId = self::$config['test_data']['existing_article_id'];
+
+        $response = $this->restrictedPost(
+            'structure/articles/' . $articleId . '/slices/1/move',
+            ['direction' => 'moveup'],
+        );
+
+        // Restricted user lacks both moveSlice[] perm and likely the structure category perm.
+        // Either 403 (Permission denied) or 404 (slice not visible) is acceptable; what we
+        // must NOT see is a 200.
+        $this->assertContains($response['status'], [403, 404]);
+    }
+
     // ==================== ADMIN CRUD: Media Category ====================
 
     public function testAdminMediaCategoryCRUD(): void

--- a/tests/StructureApiTest.php
+++ b/tests/StructureApiTest.php
@@ -481,4 +481,200 @@ class StructureApiTest extends ApiTestCase
         $this->assertStatus(404, $response);
         $this->assertError($response);
     }
+
+    public function testCreateArticleSliceAtTop(): void
+    {
+        $articleId = self::$config['test_data']['existing_article_id'];
+        $clangId = self::$config['test_data']['existing_clang_id'];
+        $moduleId = self::$config['test_data']['existing_module_id'];
+
+        $createResponse = $this->post('structure/articles/' . $articleId . '/slices', [
+            'module_id' => $moduleId,
+            'clang_id' => $clangId,
+            'ctype_id' => 1,
+            'priority' => 1,
+            'value1' => 'top-' . uniqid(),
+        ]);
+
+        if (201 !== $createResponse['status']) {
+            $this->markTestSkipped('Slice create not available (module/template wiring): status ' . $createResponse['status']);
+        }
+        $sliceId = (int) $createResponse['data']['slice_id'];
+
+        try {
+            $listResponse = $this->get('structure/articles/' . $articleId . '/slices', [
+                'clang_id' => $clangId,
+                'revision' => 0,
+            ]);
+            $this->assertSuccess($listResponse);
+
+            $slicesInCtype = array_values(array_filter(
+                $listResponse['data']['data'],
+                static fn (array $s): bool => 1 === (int) $s['ctype_id'],
+            ));
+            $this->assertNotEmpty($slicesInCtype);
+            $this->assertSame($sliceId, (int) $slicesInCtype[0]['id'], 'Slice with priority=1 should be first in the ctype');
+            $this->assertSame(1, (int) $slicesInCtype[0]['priority']);
+        } finally {
+            $this->delete('structure/articles/' . $articleId . '/slices/' . $sliceId);
+        }
+    }
+
+    public function testCreateArticleSliceWithoutPriorityAppends(): void
+    {
+        $articleId = self::$config['test_data']['existing_article_id'];
+        $clangId = self::$config['test_data']['existing_clang_id'];
+        $moduleId = self::$config['test_data']['existing_module_id'];
+
+        $createResponse = $this->post('structure/articles/' . $articleId . '/slices', [
+            'module_id' => $moduleId,
+            'clang_id' => $clangId,
+            'ctype_id' => 1,
+            'value1' => 'tail-' . uniqid(),
+        ]);
+        if (201 !== $createResponse['status']) {
+            $this->markTestSkipped('Slice create not available (module/template wiring): status ' . $createResponse['status']);
+        }
+        $sliceId = (int) $createResponse['data']['slice_id'];
+
+        try {
+            $listResponse = $this->get('structure/articles/' . $articleId . '/slices', [
+                'clang_id' => $clangId,
+                'revision' => 0,
+            ]);
+            $slicesInCtype = array_values(array_filter(
+                $listResponse['data']['data'],
+                static fn (array $s): bool => 1 === (int) $s['ctype_id'],
+            ));
+
+            $maxPriority = 0;
+            $newSlicePriority = null;
+            foreach ($slicesInCtype as $slice) {
+                $maxPriority = max($maxPriority, (int) $slice['priority']);
+                if ((int) $slice['id'] === $sliceId) {
+                    $newSlicePriority = (int) $slice['priority'];
+                }
+            }
+            $this->assertNotNull($newSlicePriority);
+            $this->assertSame($maxPriority, $newSlicePriority, 'Slice without priority should be appended at the end');
+        } finally {
+            $this->delete('structure/articles/' . $articleId . '/slices/' . $sliceId);
+        }
+    }
+
+    public function testMoveArticleSliceUp(): void
+    {
+        $articleId = self::$config['test_data']['existing_article_id'];
+        $clangId = self::$config['test_data']['existing_clang_id'];
+        $moduleId = self::$config['test_data']['existing_module_id'];
+
+        $first = $this->post('structure/articles/' . $articleId . '/slices', [
+            'module_id' => $moduleId, 'clang_id' => $clangId, 'ctype_id' => 1,
+            'priority' => 1, 'value1' => 'move-up-first-' . uniqid(),
+        ]);
+        if (201 !== $first['status']) {
+            $this->markTestSkipped('Slice create not available: status ' . $first['status']);
+        }
+        $firstId = (int) $first['data']['slice_id'];
+
+        $second = $this->post('structure/articles/' . $articleId . '/slices', [
+            'module_id' => $moduleId, 'clang_id' => $clangId, 'ctype_id' => 1,
+            'priority' => 2, 'value1' => 'move-up-second-' . uniqid(),
+        ]);
+        $this->assertStatus(201, $second);
+        $secondId = (int) $second['data']['slice_id'];
+
+        try {
+            $moveResponse = $this->post(
+                'structure/articles/' . $articleId . '/slices/' . $secondId . '/move',
+                ['direction' => 'moveup'],
+            );
+            $this->assertSuccess($moveResponse);
+            $this->assertSame('moveup', $moveResponse['data']['direction']);
+
+            $getSecond = $this->get('structure/articles/' . $articleId . '/slices/' . $secondId);
+            $getFirst = $this->get('structure/articles/' . $articleId . '/slices/' . $firstId);
+            $this->assertLessThan((int) $getFirst['data']['priority'], (int) $getSecond['data']['priority']);
+        } finally {
+            $this->delete('structure/articles/' . $articleId . '/slices/' . $secondId);
+            $this->delete('structure/articles/' . $articleId . '/slices/' . $firstId);
+        }
+    }
+
+    public function testMoveArticleSliceDown(): void
+    {
+        $articleId = self::$config['test_data']['existing_article_id'];
+        $clangId = self::$config['test_data']['existing_clang_id'];
+        $moduleId = self::$config['test_data']['existing_module_id'];
+
+        $first = $this->post('structure/articles/' . $articleId . '/slices', [
+            'module_id' => $moduleId, 'clang_id' => $clangId, 'ctype_id' => 1,
+            'priority' => 1, 'value1' => 'move-down-first-' . uniqid(),
+        ]);
+        if (201 !== $first['status']) {
+            $this->markTestSkipped('Slice create not available: status ' . $first['status']);
+        }
+        $firstId = (int) $first['data']['slice_id'];
+
+        $second = $this->post('structure/articles/' . $articleId . '/slices', [
+            'module_id' => $moduleId, 'clang_id' => $clangId, 'ctype_id' => 1,
+            'priority' => 2, 'value1' => 'move-down-second-' . uniqid(),
+        ]);
+        $this->assertStatus(201, $second);
+        $secondId = (int) $second['data']['slice_id'];
+
+        try {
+            $moveResponse = $this->post(
+                'structure/articles/' . $articleId . '/slices/' . $firstId . '/move',
+                ['direction' => 'movedown'],
+            );
+            $this->assertSuccess($moveResponse);
+            $this->assertSame('movedown', $moveResponse['data']['direction']);
+
+            $getFirst = $this->get('structure/articles/' . $articleId . '/slices/' . $firstId);
+            $getSecond = $this->get('structure/articles/' . $articleId . '/slices/' . $secondId);
+            $this->assertGreaterThan((int) $getSecond['data']['priority'], (int) $getFirst['data']['priority']);
+        } finally {
+            $this->delete('structure/articles/' . $articleId . '/slices/' . $secondId);
+            $this->delete('structure/articles/' . $articleId . '/slices/' . $firstId);
+        }
+    }
+
+    public function testMoveArticleSliceInvalidDirection(): void
+    {
+        $articleId = self::$config['test_data']['existing_article_id'];
+        $clangId = self::$config['test_data']['existing_clang_id'];
+        $moduleId = self::$config['test_data']['existing_module_id'];
+
+        $createResponse = $this->post('structure/articles/' . $articleId . '/slices', [
+            'module_id' => $moduleId, 'clang_id' => $clangId, 'ctype_id' => 1,
+            'value1' => 'bad-direction-' . uniqid(),
+        ]);
+        if (201 !== $createResponse['status']) {
+            $this->markTestSkipped('Slice create not available: status ' . $createResponse['status']);
+        }
+        $sliceId = (int) $createResponse['data']['slice_id'];
+
+        try {
+            $response = $this->post(
+                'structure/articles/' . $articleId . '/slices/' . $sliceId . '/move',
+                ['direction' => 'sideways'],
+            );
+            $this->assertStatus(400, $response);
+            $this->assertError($response);
+        } finally {
+            $this->delete('structure/articles/' . $articleId . '/slices/' . $sliceId);
+        }
+    }
+
+    public function testMoveArticleSliceNotFound(): void
+    {
+        $articleId = self::$config['test_data']['existing_article_id'];
+        $response = $this->post(
+            'structure/articles/' . $articleId . '/slices/999999/move',
+            ['direction' => 'moveup'],
+        );
+        $this->assertStatus(404, $response);
+        $this->assertError($response);
+    }
 }


### PR DESCRIPTION
## Summary

- **Add `priority` body param to `POST /api/structure/articles/{id}/slices`.** Optional; when omitted, behaviour is unchanged (slice appended at end). When set (e.g. `priority: 1`), the slice is inserted at that position within its `(article, clang, ctype)` group. The value is forwarded into the `$data` array of `rex_content_service::addSlice()`, which already understands `priority` (`content_service.php:17-24`) and re-normalises the sequence via `rex_sql_util::organizePriorities()`. No new SQL, no new EPs.
- **New `POST /api/structure/articles/{id}/slices/{slice_id}/move` endpoint** with body `{ "direction": "moveup" | "movedown" }`. Mirrors REDAXO core `rex_api_content_move_slice::execute()` 1:1 (`addons/structure/plugins/content/lib/api_functions/api_content.php`). `clang_id` and `module_id` are derived from the slice row. Permission cascade for session-cookie callers: `moveSlice[]` perm → structure category perm → modules complex-perm. Admins bypass `moveSlice[]`. Bearer-token callers pass through scope-based auth (`structure/articles/slices/move`). On boundary (`moveup` on first slice etc.) `rex_api_exception` surfaces as `422` with the original i18n message.
- **Backend mirror is automatic** via `RoutePackage/Backend/Structure.php` — `POST /api/backend/structure/articles/{id}/slices/{slice_id}/move` is available with session-cookie auth without a separate Backend implementation.
- **Out of scope by design** (CLAUDE.md "exaktes Spiegeln des Core-Verhaltens"): updating `priority` via `PATCH /slices/{id}` (backend edit page also doesn't), absolute-position moves, and convenience `move-to-top`/`move-to-bottom` endpoints (use `priority: 1` on add instead).

## Test plan

- [ ] `./vendor/bin/phpunit tests/StructureApiTest.php` against a configured `tests/.env` instance — covers `testCreateArticleSliceAtTop`, `testCreateArticleSliceWithoutPriorityAppends`, `testMoveArticleSliceUp`, `testMoveArticleSliceDown`, `testMoveArticleSliceInvalidDirection`, `testMoveArticleSliceNotFound`.
- [ ] `./vendor/bin/phpunit tests/BackendApiTest.php` — `testAdminCreateArticleSliceAtTop`, `testAdminMoveArticleSlice`, `testRestrictedUserCannotMoveArticleSlice`.
- [ ] Manual smoke against a local REDAXO instance:
  - `POST /api/structure/articles/{id}/slices` with `priority: 1` → 201, slice appears at top of its ctype in the list.
  - `POST /api/structure/articles/{id}/slices/{slice_id}/move` with `direction: "movedown"` → 200, list reflects new order.
  - `POST .../move` with `direction: "moveup"` on the top-most slice → 422.
  - `POST .../move` with `direction: "sideways"` → 400.
- [ ] Swagger UI (`/redaxo/index.php?page=api/openapi`): new `priority` field appears on the add-slice request schema, new `/move` endpoint is listed under structure.
- [ ] Token-Scope dropdown in the backend shows `structure/articles/slices/move` and `backend/structure/articles/slices/move`; a token without the scope returns 401 on the new endpoint.