### PR TITLE
Slice-Endpunkte: value20 ergänzt (#52)

### DIFF
--- a/lib/RoutePackage/Structure.php
+++ b/lib/RoutePackage/Structure.php
@@ -319,7 +319,7 @@ class Structure extends RoutePackage
             new BearerAuth()
         );
 
-        for ($i = 1; $i <= 19; ++$i) {
+        for ($i = 1; $i <= 20; ++$i) {
             $Values['value' . $i] = [
                 'type' => 'string',
                 'required' => false,
@@ -431,7 +431,7 @@ class Structure extends RoutePackage
                                 'default' => 0,
                             ],
                         ],
-                        $Values, // value1...19
+                        $Values, // value1...20
                         $Medias, // media1...10
                         $Medialists, // medialist1...10
                         $Links, // link1...10
@@ -934,14 +934,14 @@ class Structure extends RoutePackage
             ], 404);
         }
 
-        // value1...19
-        // media1...19
+        // value1...20
+        // media1...10
         // medialist1...10
         // link1...10
         // linklist1...10
 
         $SliceData = ['revision' => (int) $Data['revision']];
-        for ($i = 1; $i <= 19; ++$i) {
+        for ($i = 1; $i <= 20; ++$i) {
             $SliceData['value' . $i] = $Data['value' . $i];
             if ($i <= 10) {
                 $SliceData['media' . $i] = $Data['media' . $i];
@@ -1312,7 +1312,7 @@ class Structure extends RoutePackage
         }
 
         $UpdateData = [];
-        for ($i = 1; $i <= 19; ++$i) {
+        for ($i = 1; $i <= 20; ++$i) {
             if (null !== $Data['value' . $i]) {
                 $UpdateData['value' . $i] = $Data['value' . $i];
             }

--- a/tests/BackendApiTest.php
+++ b/tests/BackendApiTest.php
@@ -821,7 +821,7 @@ class BackendApiTest extends TestCase
             'value1' => 'BACKEND_TEST_live_admin_' . uniqid(),
         ]);
         if (201 !== $createResponse['status']) {
-            $this->assertContains($createResponse['status'], [400, 404]);
+            $this->assertSame(404, $createResponse['status'], 'Nur Template-/Modul-Zuordnung darf hier scheitern; 400 wäre ein Body-Fehler.');
             $this->markTestSkipped('Slice konnte nicht angelegt werden (Template/Modul-Zuordnung fehlt).');
         }
         $sliceId = $createResponse['data']['slice_id'];
@@ -878,7 +878,7 @@ class BackendApiTest extends TestCase
         ]);
         if (201 !== $createResponse['status']) {
             // Template hat das Modul evtl. nicht zugeordnet — wie im Bearer-Pendant tolerieren.
-            $this->assertContains($createResponse['status'], [400, 404]);
+            $this->assertSame(404, $createResponse['status'], 'Nur Template-/Modul-Zuordnung darf hier scheitern; 400 wäre ein Body-Fehler.');
             $this->markTestSkipped('Slice konnte nicht angelegt werden (Template/Modul-Zuordnung fehlt).');
         }
         $sliceId = $createResponse['data']['slice_id'];

--- a/tests/StructureApiTest.php
+++ b/tests/StructureApiTest.php
@@ -352,7 +352,7 @@ class StructureApiTest extends ApiTestCase
             $this->assertHasField($response, 'slice_id');
         } else {
             // Template hat möglicherweise das Modul nicht zugeordnet
-            $this->assertContains($response['status'], [400, 404]);
+            $this->assertSame(404, $response['status'], 'Nur Template-/Modul-Zuordnung darf hier scheitern; 400 wäre ein Body-Fehler.');
         }
     }
 
@@ -372,7 +372,7 @@ class StructureApiTest extends ApiTestCase
 
         if (201 !== $response['status']) {
             // Template hat das Modul im Ctype möglicherweise nicht zugeordnet
-            $this->assertContains($response['status'], [400, 404]);
+            $this->assertSame(404, $response['status'], 'Nur Template-/Modul-Zuordnung darf hier scheitern; 400 wäre ein Body-Fehler.');
             return;
         }
 
@@ -398,6 +398,48 @@ class StructureApiTest extends ApiTestCase
         $this->assertEquals(1, $detail['data']['revision']);
 
         $this->delete('structure/articles/' . $articleId . '/slices/' . $sliceId);
+    }
+
+    public function testArticleSliceStoresValue20(): void
+    {
+        $articleId = self::$config['test_data']['existing_article_id'];
+        $moduleId = self::$config['test_data']['existing_module_id'];
+        $clangId = self::$config['test_data']['existing_clang_id'];
+
+        // rex_article_slice hat 20 value-Spalten. Die Body-Definition deckte nur 19 ab,
+        // value20 wurde still verworfen und der Slice trotzdem mit 201 quittiert.
+        $response = $this->post('structure/articles/' . $articleId . '/slices', [
+            'module_id' => $moduleId,
+            'clang_id' => $clangId,
+            'ctype_id' => 1,
+            'value19' => 'neunzehn',
+            'value20' => 'zwanzig',
+        ]);
+
+        if (201 !== $response['status']) {
+            $this->assertSame(404, $response['status'], 'Nur Template-/Modul-Zuordnung darf hier scheitern; 400 wäre ein Body-Fehler.');
+            $this->markTestSkipped('Slice konnte nicht angelegt werden (Template/Modul-Zuordnung fehlt).');
+        }
+
+        $sliceId = (int) $response['data']['slice_id'];
+
+        try {
+            $detail = $this->get('structure/articles/' . $articleId . '/slices/' . $sliceId);
+            $this->assertSuccess($detail);
+            $this->assertSame('neunzehn', $detail['data']['value19']);
+            $this->assertSame('zwanzig', $detail['data']['value20']);
+
+            $update = $this->put('structure/articles/' . $articleId . '/slices/' . $sliceId, [
+                'value20' => 'zwanzig geaendert',
+            ]);
+            $this->assertSuccess($update);
+
+            $after = $this->get('structure/articles/' . $articleId . '/slices/' . $sliceId);
+            $this->assertSame('zwanzig geaendert', $after['data']['value20']);
+            $this->assertSame('neunzehn', $after['data']['value19']);
+        } finally {
+            $this->delete('structure/articles/' . $articleId . '/slices/' . $sliceId);
+        }
     }
 
     public function testCreateArticleSliceRejectsUnknownField(): void


### PR DESCRIPTION
Behebt #52. Die Analyse im Issue trifft zu: `rex_article_slice` hat 20 `value`-Spalten, die Body-Definition deckte nur 19 ab, und `value20` fiel aus der Validierung. Die drei Schleifen in `lib/RoutePackage/Structure.php` laufen jetzt bis 20 — betroffen waren `POST` und `PUT|PATCH` auf `structure/articles/{id}/slices` samt der Backend-Spiegel, die die Route klonen. Die inneren `10` für `media`, `medialist`, `link` und `linklist` bleiben, davon hat die Tabelle wirklich je zehn (ein Kommentar behauptete dort irrtümlich 19).

Reproduktion aus dem Issue nachgefahren, vorher `value20 = NULL`, jetzt:

```
POST  {"module_id":2,"ctype_id":1,"clang_id":1,"value19":"a","value20":"b"}
      → value19='a'  value20='b'
PUT   {"value20":"per PUT geaendert"}
      → value19='a'  value20='per PUT geaendert'
```

Die zweite Hälfte des Issues — „unknown body keys sollten 400 liefern statt verworfen zu werden" — ist mit #58 bereits erledigt: `getQuerySet()` hat dort einen strikten Modus bekommen, der bei den Slice-Bodys aktiv ist. Ein Tippfehler liefert jetzt `400 Unknown field(s): …`.

Ein Nebenbefund aus dem Absichern: die Slice-Tests behandelten jedes `!== 201` als „Template hat das Modul nicht zugeordnet" und übersprangen sich. Alle Template- und Modulfehler des Add-Handlers sind aber `404`; ein `400` ist immer ein Body-Fehler, also genau der Regressionsfall. In der ersten Fassung hat mein neuer Test deshalb still übersprungen statt zu scheitern — die fünf Stellen prüfen jetzt auf `404`. Gegenprobe mit zurückgedrehtem Fix: `Failed asserting that 400 is identical to 404`.

Suite 196 Tests / 2330 Assertions grün (5 Skips wie bisher).

---
*Dieser Text wurde durch eine KI erstellt.*
