### PR TITLE
Unique-Index auf api_token.token (#26)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,8 @@ Konfigurationswerte (Token, Backend-Credentials, existierende IDs) kommen aus `t
 
 ### Datenbank
 
-- `rex_api_token`-Tabelle — Speichert API-Tokens mit `name`, `token`, `status`, `scopes` (kommagetrennte Scope-Strings)
+- `rex_api_token`-Tabelle — Speichert API-Tokens mit `name`, `token`, `status`, `scopes` (kommagetrennte Scope-Strings), `expires_at` (nullable)
+- **Unique-Index auf `token`**: `Token::getByToken()` nimmt den ersten Treffer, ein doppelter Wert würde den zweiten Eintrag samt Scopes unwirksam machen. `install.php` legt den Index nur an, wenn die Spalte keine Duplikate enthält — sonst bräche das Update einer Altinstallation ab; stattdessen landet eine Warnung im System-Log und der Index entsteht beim nächsten Update. Die Token-Seite braucht dazu den YForm-Validator `unique`: ohne ihn scheitert der INSERT still, YForm meldet nichts und springt zurück zur Liste, als wäre gespeichert worden.
 
 ## Wichtige Hinweise
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 Die meisten APIs haben Authentifizierung. Das heisst, es muss ein API-Token im Backend angelegt werden, um die Endpunkte nutzen zu können, wie auch der entsprechende Scope gesetzt werden.
 Andere APIs haben eine Backend-Authentifizierung, die dann über den Backend-User läuft, d.h. es kann der Session Cookie verwendet werden, um die Endpunkte zu nutzen.
 
+Der Token-Wert muss eindeutig sein — die Spalte trägt einen Unique-Index, und die Token-Seite lehnt einen bereits vergebenen Wert mit einer Meldung ab. Enthält eine bestehende Installation doppelte Werte, wird der Index beim Update übersprungen und eine Warnung ins System-Log geschrieben; nach dem Auflösen der Duplikate greift er beim nächsten Update.
+
 ### Ablaufdatum für Tokens
 
 Ein Token kann optional ablaufen. Auf der Token-Seite schaltet die Checkbox **Ablauf aktiv** das Feld **Ablaufdatum** frei; ohne sie bleibt das Token unbegrenzt gültig — so verhalten sich auch alle Tokens, die vor dem Update angelegt wurden.

--- a/install.php
+++ b/install.php
@@ -1,13 +1,40 @@
 <?php
 
-rex_sql_table::get(rex::getTable('api_token'))
+$table = rex_sql_table::get(rex::getTable('api_token'));
+$tableExisted = $table->exists();
+
+$table
 ->ensurePrimaryIdColumn()
 ->ensureColumn(new rex_sql_column('name', 'varchar(191)'))
 ->ensureColumn(new rex_sql_column('token', 'varchar(191)'))
 ->ensureColumn(new rex_sql_column('status', 'tinyint(1)', false, '1'))
 ->ensureColumn(new rex_sql_column('scopes', 'text'))
-->ensureColumn(new rex_sql_column('expires_at', 'datetime', true))
-->ensure();
+->ensureColumn(new rex_sql_column('expires_at', 'datetime', true));
+
+// Der Token-Wert muss eindeutig sein: Token::getByToken() nimmt den ersten Treffer,
+// bei einem doppelten Wert wäre der zweite Eintrag samt seiner Scopes unwirksam.
+// Bei einer bestehenden Installation kann die Spalte aber schon Duplikate enthalten;
+// dann würde das Anlegen des Index das Update abbrechen. In dem Fall bleibt der Index
+// aus und der Vorgang wird protokolliert, damit die Duplikate von Hand aufgelöst
+// werden können — beim nächsten Update greift er dann.
+$duplicates = [];
+if ($tableExisted) {
+    $duplicates = rex_sql::factory()->getArray(
+        'SELECT token, COUNT(*) AS amount FROM ' . rex::getTable('api_token') . ' GROUP BY token HAVING amount > 1',
+    );
+}
+
+if ([] === $duplicates) {
+    $table->ensureIndex(new rex_sql_index('token', ['token'], rex_sql_index::UNIQUE));
+} else {
+    rex_logger::factory()->warning(
+        'api: Unique-Index auf api_token.token nicht angelegt, es gibt {amount} doppelte Token-Werte. '
+        . 'Doppelte Tokens auf der Seite API > Token auflösen, dann das AddOn erneut aktualisieren.',
+        ['amount' => count($duplicates)],
+    );
+}
+
+$table->ensure();
 
 // Altbestände aus früheren Versionen normalisieren: die Spalte wird nullable
 // angelegt, ein bestehendes NOT-NULL-Feld kann aber 0000-00-00 00:00:00 enthalten.

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -21,6 +21,7 @@ api_active = aktiv
 api_inactive = inaktiv
 api_token_create = API-Token erstellen
 api_token_token_notice = Wie wäre es mit diesem Token {0}
+api_token_token_unique = Dieses Token ist bereits vergeben
 api_token_token_scopes = Scopes
 api_token_expire_active = Ablauf aktiv
 api_token_expires_at = Ablaufdatum

--- a/pages/token.php
+++ b/pages/token.php
@@ -54,6 +54,10 @@ if ('delete' == $func && !rex_csrf_token::factory($_csrf_key)->isValid()) {
     $form_data[] = 'checkbox|expires_active|translate:api_token_expire_active|' . $expires_active_default . '|no_db';
     $form_data[] = 'datetime|expires_at|translate:api_token_expires_at|' . date('Y') . '|+10|Y-m-d H:i:s|1||select|||+1 year';
     $form_data[] = 'validate|empty|token|translate:api_token_token_validate';
+    // Die Spalte trägt einen Unique-Index (siehe install.php). Ohne diesen Validator
+    // scheitert der INSERT still: YForm meldet nichts und springt zurück zur Liste,
+    // als wäre gespeichert worden.
+    $form_data[] = 'validate|unique|token|' . rex_i18n::msg('api_token_token_unique') . '|' . $table;
     $form_data[] = 'choice|scopes|translate:api_token_token_scopes|' . implode(',', Token::getAvailableScopes()) . '||1';
 
     $yform = rex_yform::factory();


### PR DESCRIPTION
Behebt #26. `Token::getByToken()` nimmt den ersten Treffer — bei zwei Einträgen mit demselben Token-Wert wäre der zweite samt seiner Scopes unwirksam, ohne dass es auffällt. Die Spalte hatte bisher keinen Index.

**Rücksicht auf bestehende Installationen.** `install.php` legt den Unique-Index nur an, wenn die Spalte keine Duplikate enthält. Sonst würde das Anlegen das Update mit einem SQL-Fehler abbrechen. In dem Fall bleibt der Index aus, die Daten bleiben unangetastet, und eine Warnung landet im System-Log — mit der Zahl der Duplikate und dem Hinweis, sie auf der Token-Seite aufzulösen. Beim nächsten Update greift der Index dann. Die Sequenz ist durchgemessen:

```
Altinstallation mit 1 Duplikat, kein Index
  → update.php läuft durch, Index bleibt aus, Duplikate unverändert, Log-Eintrag geschrieben
Duplikat aufgelöst
  → update.php legt den Index an
```

**Die UI braucht den Validator dazu.** Ohne ihn scheitert der INSERT still: YForm meldet nichts, springt zurück zur Liste, und der Eintrag fehlt einfach — im Backend nachgestellt, kein Fehler in der Oberfläche, kein Log-Eintrag. Mit dem YForm-Validator `unique` bleibt das Formular samt Eingaben stehen und zeigt „Dieses Token ist bereits vergeben". Beim Bearbeiten schlägt er nicht auf den eigenen Datensatz an, weil `pages/token.php` `main_where` setzt — ebenfalls geprüft: Speichern ohne Änderung am Token-Wert läuft durch.

Suite 196 Tests / 2330 Assertions grün (5 Skips wie bisher).

---
*Dieser Text wurde durch eine KI erstellt.*
