### PR TITLE
Metainfo-Werte: Nicht-Skalare zurückweisen statt still zu verwerfen

### DIFF
--- a/lib/RoutePackage/Metainfo.php
+++ b/lib/RoutePackage/Metainfo.php
@@ -782,7 +782,7 @@ class Metainfo extends RoutePackage
         }
 
         $fields = self::loadFieldsForPrefix('med_');
-        $error = self::validatePatchKeys($body, $fields);
+        $error = self::validatePatch($body, $fields);
         if (null !== $error) {
             return $error;
         }
@@ -837,7 +837,7 @@ class Metainfo extends RoutePackage
         }
 
         $fields = self::loadFieldsForPrefix('clang_');
-        $error = self::validatePatchKeys($body, $fields);
+        $error = self::validatePatch($body, $fields);
         if (null !== $error) {
             return $error;
         }
@@ -906,7 +906,7 @@ class Metainfo extends RoutePackage
 
         $prefix = $isArticle ? 'art_' : 'cat_';
         $fields = self::loadFieldsForPrefix($prefix);
-        $error = self::validatePatchKeys($body, $fields);
+        $error = self::validatePatch($body, $fields);
         if (null !== $error) {
             return $error;
         }
@@ -1194,14 +1194,14 @@ class Metainfo extends RoutePackage
      * @param array<string, mixed> $body
      * @param list<array{name: string, type_id: int, attributes: string}> $fields
      */
-    private static function validatePatchKeys(array $body, array $fields): ?Response
+    private static function validatePatch(array $body, array $fields): ?Response
     {
         $known = [];
         foreach ($fields as $f) {
             if (rex_metainfo_default_type::LEGEND === $f['type_id']) {
                 continue;
             }
-            $known[$f['name']] = true;
+            $known[$f['name']] = $f;
         }
 
         $unknown = [];
@@ -1218,7 +1218,64 @@ class Metainfo extends RoutePackage
             ], 422);
         }
 
+        // Werte-Typen prüfen, bevor formatValueForStorage() sie anfasst: dort wird alles
+        // Nicht-Skalare zu null, was mit Status 200 wie ein erfolgreicher Schreibvorgang
+        // aussah, obwohl nichts ankam.
+        $invalid = [];
+        foreach ($body as $key => $value) {
+            $field = $known[$key];
+            $expected = self::expectedValueType((int) $field['type_id'], (string) $field['attributes']);
+
+            if (null === $value) {
+                continue;
+            }
+
+            if ('list' === $expected) {
+                if (is_scalar($value)) {
+                    continue;
+                }
+                if (!is_array($value)) {
+                    $invalid[$key] = 'expects an array of scalar values, a scalar value or null';
+                    continue;
+                }
+                foreach ($value as $part) {
+                    if (null !== $part && !is_scalar($part)) {
+                        $invalid[$key] = 'expects an array of scalar values, a scalar value or null';
+                        break;
+                    }
+                }
+                continue;
+            }
+
+            if (!is_scalar($value)) {
+                $invalid[$key] = 'date' === $expected
+                    ? 'expects a timestamp, a date string or null'
+                    : 'expects a scalar value or null';
+            }
+        }
+
+        if (count($invalid) > 0) {
+            return new JsonResponse([
+                'error' => 'Invalid value for metainfo field(s): ' . implode(', ', array_keys($invalid)),
+                'details' => $invalid,
+            ], 400);
+        }
+
         return null;
+    }
+
+    /**
+     * @return 'list'|'date'|'scalar'
+     */
+    private static function expectedValueType(int $typeId, string $attributes): string
+    {
+        if (self::isMultiValueType($typeId, $attributes)) {
+            return 'list';
+        }
+        if (self::isDateType($typeId)) {
+            return 'date';
+        }
+        return 'scalar';
     }
 
     /**

--- a/tests/MetainfoApiTest.php
+++ b/tests/MetainfoApiTest.php
@@ -279,6 +279,74 @@ class MetainfoApiTest extends ApiTestCase
         }
     }
 
+    /**
+     * Ein Objekt auf einem Skalar-Feld wurde bis #66 still zu null verworfen und
+     * mit 200 quittiert. Der zweite Wert im Body ist der Kontrollwert: er beweist,
+     * dass der Patch als Ganzes abgelehnt wird und nicht teilweise durchläuft.
+     */
+    public function testMediaValuesRejectNonScalarOnScalarField(): void
+    {
+        $mediaList = $this->get('media', ['per_page' => 1]);
+        if (empty($mediaList['data']['data'])) {
+            $this->markTestSkipped('Keine Media-Items in der DB vorhanden.');
+        }
+        $filename = $mediaList['data']['data'][0]['filename'];
+
+        $scalarField = 'med_reject_' . uniqid();
+        $controlField = 'med_control_' . uniqid();
+        $scalar = $this->post('metainfo/fields', ['name' => $scalarField, 'title' => 'Reject non-scalar', 'type_id' => 1]);
+        $this->assertStatus(201, $scalar);
+        $control = $this->post('metainfo/fields', ['name' => $controlField, 'title' => 'Control value', 'type_id' => 1]);
+        $this->assertStatus(201, $control);
+
+        try {
+            $patch = $this->patch('media/' . $filename . '/metainfo', [
+                $scalarField => ['de' => 'Hallo'],
+                $controlField => 'KONTROLLWERT',
+            ]);
+
+            $this->assertStatus(400, $patch);
+            $this->assertArrayHasKey($scalarField, $patch['data']['details']);
+            $this->assertArrayNotHasKey($controlField, $patch['data']['details']);
+
+            // Der Kontrollwert darf nicht geschrieben worden sein.
+            $verify = $this->get('media/' . $filename . '/metainfo');
+            $this->assertNull($verify['data']['data'][$controlField]);
+        } finally {
+            $this->delete('metainfo/fields/' . (int) $scalar['data']['id']);
+            $this->delete('metainfo/fields/' . (int) $control['data']['id']);
+        }
+    }
+
+    /** Multi-Value-Felder nehmen Arrays weiterhin an — nur verschachtelte Werte darin nicht. */
+    public function testMediaValuesAcceptArrayOnMultiValueFieldButRejectNested(): void
+    {
+        $mediaList = $this->get('media', ['per_page' => 1]);
+        if (empty($mediaList['data']['data'])) {
+            $this->markTestSkipped('Keine Media-Items in der DB vorhanden.');
+        }
+        $filename = $mediaList['data']['data'][0]['filename'];
+
+        $name = 'med_multi_' . uniqid();
+        // type_id 5 = CHECKBOX, ein Multi-Value-Typ
+        $create = $this->post('metainfo/fields', ['name' => $name, 'title' => 'Multi value', 'type_id' => 5]);
+        $this->assertStatus(201, $create);
+        $fieldId = (int) $create['data']['id'];
+
+        try {
+            $ok = $this->patch('media/' . $filename . '/metainfo', [$name => ['a', 'b']]);
+            $this->assertSuccess($ok);
+            $this->assertSame(['a', 'b'], $ok['data']['data'][$name]);
+
+            $nested = $this->patch('media/' . $filename . '/metainfo', [$name => ['a', ['b']]]);
+            $this->assertStatus(400, $nested);
+
+            $this->patch('media/' . $filename . '/metainfo', [$name => []]);
+        } finally {
+            $this->delete('metainfo/fields/' . $fieldId);
+        }
+    }
+
     public function testClangValuesGetReturnsMap(): void
     {
         $clangId = self::$config['test_data']['existing_clang_id'];


### PR DESCRIPTION
Behebt #66: ein Metainfo-Wert, der kein Skalar ist, wurde still zu `null` und die Antwort meldete trotzdem `200`.

`validatePatchKeys()` heißt jetzt `validatePatch()` und prüft zusätzlich die Werte-Typen, bevor geschrieben wird — Skalar-Felder nehmen Skalare und `null`, Datumsfelder zusätzlich Timestamps und Datums-Strings, Multi-Value-Felder Arrays aus Skalaren. Verstöße ergeben `400` mit Feldname und erwartetem Typ. Die Prüfung sitzt vor `applyValuePatch()`, der Patch wird also als Ganzes abgelehnt statt teilweise geschrieben; alle vier Werte-Endpunkte (Artikel, Kategorie, Medium, Sprache) laufen durch dieselbe Methode.

Zwei Tests in `MetainfoApiTest`, beide mit Kontrollwert im selben Body, der beweist, dass der Patch komplett abgelehnt wird. Gegenprobe gemacht: ohne den Fix schlagen beide mit „Failed asserting that 200 is identical to 400" fehl.

**Hinweis zur Suite:** 5 Tests schlagen derzeit fehl (`testArticleValuesRoundtrip`, `testCategoryValuesRoundtrip`, `testFieldCrudRoundtrip`, `testAdminCanReadAndWriteArticleMetainfo`, `testAdminCanReadAndWriteCategoryMetainfo`) — alle legen `art_`/`cat_`-Felder an und scheitern an `ERROR 1118: Row size too large` beim `ALTER TABLE rex_article` der Testinstallation, nicht am Code. Belegt: mit gestashter Änderung fallen exakt dieselben Tests. Alles, was auf `rex_media` und `rex_clang` läuft, ist grün. Der dabei gefundene Folgefehler steht in #67.

---
*Dieser Text wurde durch eine KI erstellt.*
