### PR TITLE
Metainfo-Feld: fehlgeschlagenes ALTER melden und Zeile zurücknehmen

### DIFF
--- a/lib/RoutePackage/Metainfo.php
+++ b/lib/RoutePackage/Metainfo.php
@@ -605,6 +605,19 @@ class Metainfo extends RoutePackage
             return new JsonResponse(['error' => $result], 409);
         }
 
+        // rex_metainfo_add_field() fuegt erst die Zeile ein und legt dann die Spalte an;
+        // schlaegt das ALTER fehl, faengt rex_metainfo_table_manager::addColumn() die
+        // Exception ab und gibt false zurueck. Ohne diese Pruefung meldete die API 201
+        // fuer ein Feld, dessen Spalte fehlt -- und das war anschliessend unloeschbar,
+        // weil rex_metainfo_delete_field() ohne Spalte abbricht.
+        if (false === $result) {
+            self::deleteFieldRowByName($name);
+            return new JsonResponse([
+                'error' => 'Metainfo field could not be created: the database column was not added',
+                'name' => $name,
+            ], 500);
+        }
+
         try {
             $row = rex_sql::factory()->getArray(
                 'SELECT id FROM ' . rex::getTable('metainfo_field') . ' WHERE name = :name LIMIT 1',
@@ -703,6 +716,19 @@ class Metainfo extends RoutePackage
         }
 
         self::ensureMetainfoFunctions();
+
+        // Fehlt zu einer vorhandenen Zeile die Spalte, bricht rex_metainfo_delete_field()
+        // mit "invalid name" ab und der Datensatz bliebe dauerhaft stehen. Solche Reste
+        // entstehen, wenn das ALTER beim Anlegen scheitert; sie werden hier direkt entfernt.
+        $orphan = self::findOrphanFieldRow((int) $Parameter['id']);
+        if (null !== $orphan) {
+            self::deleteFieldRowByName($orphan);
+            return new JsonResponse([
+                'message' => 'Metainfo field deleted',
+                'id' => (int) $Parameter['id'],
+                'note' => 'The database column was missing; only the field definition was removed',
+            ], 200);
+        }
 
         $result = rex_metainfo_delete_field((int) $Parameter['id']);
 
@@ -1123,6 +1149,56 @@ class Metainfo extends RoutePackage
             return rex_metainfo_meta_prefix($name);
         } catch (InvalidArgumentException) {
             return '';
+        }
+    }
+
+    /**
+     * Gibt den Feldnamen zurueck, wenn die Zeile existiert, ihre Spalte in der
+     * Meta-Tabelle aber fehlt. Sonst null.
+     */
+    private static function findOrphanFieldRow(int $id): ?string
+    {
+        try {
+            $rows = rex_sql::factory()->getArray(
+                'SELECT name FROM ' . rex::getTable('metainfo_field') . ' WHERE id = :id LIMIT 1',
+                [':id' => $id],
+            );
+        } catch (rex_sql_exception) {
+            return null;
+        }
+
+        if (0 === count($rows)) {
+            return null;
+        }
+
+        $name = (string) $rows[0]['name'];
+        $table = self::tableForName($name);
+        if ('' === $table) {
+            return null;
+        }
+
+        try {
+            $columns = rex_sql::factory()->getArray(
+                'SELECT column_name FROM information_schema.columns WHERE table_schema = database() AND table_name = :table AND column_name = :column LIMIT 1',
+                [':table' => $table, ':column' => $name],
+            );
+        } catch (rex_sql_exception) {
+            return null;
+        }
+
+        return 0 === count($columns) ? $name : null;
+    }
+
+    private static function deleteFieldRowByName(string $name): void
+    {
+        try {
+            $sql = rex_sql::factory();
+            $sql->setQuery(
+                'DELETE FROM ' . rex::getTable('metainfo_field') . ' WHERE name = :name',
+                [':name' => $name],
+            );
+        } catch (rex_sql_exception) {
+            // Die Zeile bleibt dann stehen, der Aufrufer meldet den Fehler ohnehin.
         }
     }
 

--- a/tests/MetainfoApiTest.php
+++ b/tests/MetainfoApiTest.php
@@ -284,6 +284,29 @@ class MetainfoApiTest extends ApiTestCase
      * mit 200 quittiert. Der zweite Wert im Body ist der Kontrollwert: er beweist,
      * dass der Patch als Ganzes abgelehnt wird und nicht teilweise durchläuft.
      */
+    /**
+     * Schlaegt das ALTER beim Anlegen fehl, meldete die API bis #67 trotzdem 201 und liess
+     * eine Zeile ohne Spalte zurueck, die sich danach nicht mehr loeschen liess. Der
+     * ueberlange Name erzwingt den Fehlschlag, ohne die Tabelle zu veraendern: MySQL
+     * erlaubt hoechstens 64 Zeichen fuer einen Spaltennamen.
+     */
+    public function testFieldAddRollsBackWhenColumnCannotBeCreated(): void
+    {
+        $name = 'art_' . str_repeat('x', 70);
+
+        $create = $this->post('metainfo/fields', [
+            'name' => $name,
+            'title' => 'Rollback probe',
+            'type_id' => 1,
+        ]);
+
+        $this->assertStatus(500, $create);
+
+        $list = $this->get('metainfo/fields', ['per_page' => 200]);
+        $names = array_column($list['data']['data'], 'name');
+        $this->assertNotContains($name, $names, 'Die Felddefinition darf nach dem fehlgeschlagenen ALTER nicht zurueckbleiben.');
+    }
+
     public function testMediaValuesRejectNonScalarOnScalarField(): void
     {
         $mediaList = $this->get('media', ['per_page' => 1]);


### PR DESCRIPTION
Behebt #67.

`handleFieldAdd` behandelt den `false`-Rückgabewert von `rex_metainfo_add_field()` jetzt als Fehler, nimmt die bereits eingefügte Zeile zurück und antwortet mit `500`. `handleFieldDelete` entfernt eine vorhandene Zeile, zu der die Spalte fehlt, direkt — statt dauerhaft `404` zu liefern, weil `rex_metainfo_delete_field()` ohne Spalte abbricht.

Vorher/nachher an der laufenden Installation, der Fehlschlag wird über einen 74 Zeichen langen Spaltennamen erzwungen (MySQL erlaubt 64) — das trifft denselben `false`-Pfad wie ein `Row size too large`, ohne die Tabelle anzufassen:

```
ohne Fix:  POST   → 201 "Metainfo field created", id 632   (Spalte fehlt)
           DELETE → 404 "Der angegebene Spaltenname ist ungültig!"   dauerhaft

mit Fix:   POST   → 500, keine Zeile zurückgeblieben
           DELETE → 200 + note "The database column was missing; …"
```

Ein Test deckt den Add-Rollback ab; Gegenprobe gemacht („Failed asserting that 201 is identical to 500"). Der Orphan-Löschpfad ist nicht automatisiert — mit dem Fix lässt sich über die API kein verwaister Datensatz mehr erzeugen, ein Test müsste ihn per SQL herstellen. Die Messung oben zeigt ihn.

Suite: **199 Tests, 2342 Assertions, 5 Skips**, keine Fehler.

---
*Dieser Text wurde durch eine KI erstellt.*
