### PR TITLE
Upload: Größenlimits als 413 melden statt als generisches 400

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,28 @@ Alle Listen-Endpunkte unterstützen Paginierung über Query-Parameter:
 
 Beispiel: `GET /api/media?page=2&per_page=10`
 
+### Upload-Grenzen
+
+`POST /api/media` unterliegt den PHP-Limits der Installation. Die Antwort unterscheidet die Fälle, damit ein Client erkennt, woran es liegt:
+
+| Situation | Status | Antwort |
+|---|---|---|
+| Datei größer als `upload_max_filesize` | `413` | `error` plus `limits` mit beiden Werten in Bytes |
+| Request größer als `post_max_size` (PHP verwirft den ganzen Body) | `413` | zusätzlich `content_length` |
+| Kein `file`-Feld im Request | `400` | `No file uploaded` |
+| Übertragung abgebrochen | `400` | `Upload incomplete` |
+
+Beispiel:
+
+```json
+{
+  "error": "File too large: exceeds upload_max_filesize",
+  "limits": { "upload_max_filesize": 2097152, "post_max_size": 8388608 }
+}
+```
+
+Wer regelmäßig größere Dateien überträgt, erhöht die Limits in der `php.ini` — oder wartet auf die Chunked-Upload-Endpunkte (Issue #39).
+
 ### Medien suchen und filtern
 
 `GET /api/media` kennt neben den Bereichsfiltern (`filesize_min/max`, `width_min/max`, `height_min/max`) drei Filter, die dasselbe leisten wie die Suche der Backend-Medienliste (`rex_media_service::getList()`):

--- a/lib/RoutePackage/Media.php
+++ b/lib/RoutePackage/Media.php
@@ -29,6 +29,14 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Route;
 
 use const JSON_PRETTY_PRINT;
+use const UPLOAD_ERR_CANT_WRITE;
+use const UPLOAD_ERR_EXTENSION;
+use const UPLOAD_ERR_FORM_SIZE;
+use const UPLOAD_ERR_INI_SIZE;
+use const UPLOAD_ERR_NO_FILE;
+use const UPLOAD_ERR_NO_TMP_DIR;
+use const UPLOAD_ERR_OK;
+use const UPLOAD_ERR_PARTIAL;
 
 class Media extends RoutePackage
 {
@@ -464,6 +472,79 @@ class Media extends RoutePackage
     }
 
     /**
+     * Prueft den Upload-Zustand und liefert eine passende Fehlerantwort, oder null bei Erfolg.
+     *
+     * Ueberschreitet der Request post_max_size, verwirft PHP den gesamten Body: $_FILES und
+     * $_POST sind dann leer, obwohl ein Content-Length ankam. Ohne diese Unterscheidung sahen
+     * "keine Datei geschickt", "Datei zu gross" und "Body zu gross" fuer den Client gleich aus
+     * -- ein Client konnte also nicht erkennen, dass er die Datei stueckeln muss.
+     *
+     * @param array<string, mixed>|null $file
+     */
+    private static function uploadErrorResponse(?array $file): ?Response
+    {
+        $limits = [
+            'upload_max_filesize' => self::iniBytes((string) ini_get('upload_max_filesize')),
+            'post_max_size' => self::iniBytes((string) ini_get('post_max_size')),
+        ];
+        $contentLength = (int) ($_SERVER['CONTENT_LENGTH'] ?? 0);
+
+        if (null === $file) {
+            // Body komplett verworfen: es kam etwas an, aber PHP hat nichts geparst.
+            if ($contentLength > 0 && 0 === count($_POST) && $limits['post_max_size'] > 0 && $contentLength > $limits['post_max_size']) {
+                return new JsonResponse([
+                    'error' => 'Request body too large: the whole request was discarded because it exceeds post_max_size',
+                    'content_length' => $contentLength,
+                    'limits' => $limits,
+                ], 413);
+            }
+            return new JsonResponse(['error' => 'No file uploaded'], 400);
+        }
+
+        $error = (int) ($file['error'] ?? UPLOAD_ERR_NO_FILE);
+
+        if (UPLOAD_ERR_OK === $error) {
+            return null;
+        }
+
+        return match ($error) {
+            UPLOAD_ERR_INI_SIZE => new JsonResponse([
+                'error' => 'File too large: exceeds upload_max_filesize',
+                'limits' => $limits,
+            ], 413),
+            UPLOAD_ERR_FORM_SIZE => new JsonResponse([
+                'error' => 'File too large: exceeds the MAX_FILE_SIZE given in the request',
+                'limits' => $limits,
+            ], 413),
+            UPLOAD_ERR_PARTIAL => new JsonResponse([
+                'error' => 'Upload incomplete: only part of the file was received',
+            ], 400),
+            UPLOAD_ERR_NO_FILE => new JsonResponse(['error' => 'No file uploaded'], 400),
+            UPLOAD_ERR_NO_TMP_DIR, UPLOAD_ERR_CANT_WRITE, UPLOAD_ERR_EXTENSION => new JsonResponse([
+                'error' => 'Upload failed on the server',
+                'upload_error' => $error,
+            ], 500),
+            default => new JsonResponse(['error' => 'Upload error', 'upload_error' => $error], 400),
+        };
+    }
+
+    /** Wandelt einen ini-Groessenwert wie "8M" in Bytes. */
+    private static function iniBytes(string $value): int
+    {
+        $value = trim($value);
+        if ('' === $value) {
+            return 0;
+        }
+        $number = (int) $value;
+        return match (strtolower(substr($value, -1))) {
+            'g' => $number * 1024 * 1024 * 1024,
+            'm' => $number * 1024 * 1024,
+            'k' => $number * 1024,
+            default => $number,
+        };
+    }
+
+    /**
      * Dateiendung aus dem Dateinamen, identisch zu rex_media_service::getList()
      * (mediapool/lib/service_media.php:310).
      */
@@ -749,8 +830,9 @@ class Media extends RoutePackage
     /** @api */
     public static function handleAddMedia($Parameter, array $Route = []): Response
     {
-        if (!isset($_FILES['file']) || UPLOAD_ERR_OK !== $_FILES['file']['error']) {
-            return new JsonResponse(['error' => 'No file uploaded or upload error'], 400);
+        $uploadError = self::uploadErrorResponse($_FILES['file'] ?? null);
+        if (null !== $uploadError) {
+            return $uploadError;
         }
 
         $request = rex::getRequest();

--- a/tests/MediaApiTest.php
+++ b/tests/MediaApiTest.php
@@ -218,6 +218,63 @@ class MediaApiTest extends ApiTestCase
         $this->trackResource('media', $response['data']['filename'] . '/delete');
     }
 
+    public function testUploadWithoutFileReturns400(): void
+    {
+        $response = $this->postMultipart('media', ['category_id' => 0, 'title' => 'kein Upload']);
+
+        $this->assertStatus(400, $response);
+        $this->assertSame('No file uploaded', $response['data']['error']);
+    }
+
+    /**
+     * Ueberschreitet der Upload ein PHP-Limit, muss das als 413 samt Limits erkennbar sein --
+     * vorher kamen "keine Datei", "Datei zu gross" und "Body zu gross" alle als dasselbe
+     * nichtssagende 400 zurueck. Erlaubt die Installation 3 MB, ist der Fall hier nicht
+     * messbar und der Test uebersprungen statt vorgetaeuscht.
+     */
+    public function testUploadExceedingPhpLimitReturns413(): void
+    {
+        $path = rtrim(sys_get_temp_dir(), '/') . '/api-test-oversized-' . uniqid() . '.png';
+        if (false === file_put_contents($path, self::oversizedPngPayload(3 * 1024 * 1024))) {
+            $this->markTestSkipped('Testdatei konnte nicht erstellt werden.');
+        }
+
+        try {
+            $response = $this->postMultipart('media', [
+                'category_id' => 0,
+                'title' => $this->generateTestName('media'),
+            ], ['file' => $path]);
+
+            if (201 === $response['status']) {
+                $this->trackResource('media', $response['data']['filename'] . '/delete');
+                $this->markTestSkipped('Diese Installation erlaubt Uploads von 3 MB; das Limit ist so nicht messbar.');
+            }
+
+            $this->assertStatus(413, $response);
+            $this->assertArrayHasKey('limits', $response['data']);
+            $this->assertGreaterThan(0, (int) $response['data']['limits']['upload_max_filesize']);
+            $this->assertGreaterThan(0, (int) $response['data']['limits']['post_max_size']);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    /** Gueltiges PNG mit einem tEXt-Chunk als Ballast, damit die Datei die Zielgroesse erreicht. */
+    private static function oversizedPngPayload(int $bytes): string
+    {
+        $chunk = static function (string $type, string $data): string {
+            return pack('N', strlen($data)) . $type . $data . pack('N', crc32($type . $data));
+        };
+
+        return "PNG
+
+"
+            . $chunk('IHDR', pack('NNCCCCC', 1, 1, 8, 2, 0, 0, 0))
+            . $chunk('IDAT', gzcompress("    "))
+            . $chunk('tEXt', "Comment " . str_repeat('x', $bytes))
+            . $chunk('IEND', '');
+    }
+
     public function testGetMediaInfo(): void
     {
         // Erst Liste abrufen um einen existierenden Dateinamen zu bekommen


### PR DESCRIPTION
Vorarbeit zu #39. `POST /api/media` beantwortete jeden Upload-Fehler mit `400 "No file uploaded or upload error"` — damit sahen drei verschiedene Ursachen gleich aus, und ein Client konnte nicht erkennen, dass er an ein Größenlimit gestoßen ist.

An der laufenden Installation gemessen (`upload_max_filesize` 2M, `post_max_size` 8M):

| Upload | vorher | jetzt |
|---|---|---|
| 1 MB | `201` | `201` |
| 3 MB | `400` generisch | `413` + `limits` |
| 9 MB | `400` generisch | `413` + `limits` + `content_length` |
| kein `file`-Feld | `400` generisch | `400 "No file uploaded"` |

Der 9-MB-Fall ist der unangenehme: PHP verwirft bei Überschreitung von `post_max_size` den **gesamten** Body, `$_FILES` und `$_POST` sind leer. Erkannt wird er über `CONTENT_LENGTH` gegen das Limit bei leerem `$_POST`. Zusätzlich unterschieden: Abbruch während der Übertragung → `400`, serverseitiger Fehler (kein tmp-Verzeichnis, nicht schreibbar, Extension) → `500`.

Zwei Tests; der 413-Test überspringt sich explizit, falls eine Installation 3 MB erlaubt, statt einen Erfolg vorzutäuschen. Gegenprobe gemacht: ohne den Fix fallen beide („Failed asserting that 400 is identical to 413").

Suite: **205 Tests, 2371 Assertions, 5 Skips**, keine Fehler.

---
*Dieser Text wurde durch eine KI erstellt.*
