### PR TITLE
Chunked Upload für große Mediendateien

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ pnpm install && pnpm build
 Tests sind **Integrationstests**, die echte HTTP-Requests via cURL an eine laufende REDAXO-Installation senden. Setup:
 
 1. `cp tests/.env.example tests/.env` und Werte anpassen (Basis-URL, Bearer-Token, Backend-Credentials, existierende IDs).
-2. Bearer-Token im REDAXO-Backend unter `API → Token` anlegen und alle benötigten Scopes vergeben — die Test-Suite erwartet u.a. `structure/articles/slices/{list,add,get,update,delete}`, `system/clangs/*`, `modules/*`, `templates/*`, `users/*`, `media/*`, `metainfo/*`.
+2. Bearer-Token im REDAXO-Backend unter `API → Token` anlegen und alle benötigten Scopes vergeben — die Test-Suite erwartet u.a. `structure/articles/slices/{list,add,get,update,delete}`, `system/clangs/*`, `modules/*`, `templates/*`, `users/*`, `media/*` (inklusive `media/upload/*` für `MediaUploadApiTest`), `metainfo/*`.
 3. Restricted-Backend-User mit eingeschränkten Permissions anlegen (Default-Login `apitest_restricted`):
    ```bash
    redaxo/bin/console user:create apitest_restricted <password> --name="API Test Restricted"
@@ -75,6 +75,7 @@ Jede Datei definiert Routen und Handler-Methoden für eine Ressourcengruppe:
 | `Templates.php`    | Templates CRUD                                         | `templates/`     |
 | `Clangs.php`       | Sprachen CRUD                                          | `system/clangs/` |
 | `Metainfo.php`     | Metainfo-Felddefinitionen + Werte (Artikel/Kategorie/Medium/Sprache) | `metainfo/`      |
+| `MediaUpload.php`  | Chunked Upload (init/chunk/status/finalize/abort)       | `media/upload/`  |
 | `Discovery.php`    | Selbstauskunft `/api/me` (erlaubte Endpunkte, OpenAPI gefiltert)      | — (scope-frei)   |
 
 Die `lib/RoutePackage/Backend/`-Klassen erweitern jeweils ihre Bearer-Variante, klonen alle passenden Routen, hängen `backend/` an Pfad und Scope und ersetzen das Auth-Objekt durch `BackendUser`. Beim Anlegen eines neuen Bearer-Endpunkts entsteht der Backend-Spiegel automatisch — eigene `Backend/*.php`-Implementierungen sind nur nötig, wenn das Standardverhalten überschrieben werden soll (Beispiel: `Backend/Media.php`).
@@ -157,6 +158,18 @@ Erst wenn diese vier Punkte abgehakt sind, ist der Endpoint korrekt. Tests gehö
 - `rex_article.revision` ist eine Altlast: der Core befüllt die Spalte nie (überall 0) und wertet sie in seinen Artikel-Queries auch nicht aus — `rex_structure_element` kennt sie gar nicht. Revisionen leben ausschließlich in `rex_article_slice`. Die Artikel-Liste hatte deshalb einen `filter[revision]` samt hartem `revision = 0` im WHERE, der nichts bewirkte außer Erwartungen zu wecken; beides ist entfernt. Das Feld bleibt in der Artikel-Response enthalten, damit sich das Antwortschema nicht ändert.
 - Das Plugin verweigert Usern ohne `version[live_version]` das Schreiben in die Live-Version (`version/boot.php`). `Structure::checkLiveRevisionPerm()` spiegelt das für Add, Update und Delete: liegt ein Backend-User vor, ist `structure/version` aktiv und betrifft die Operation Revision 0, dann `403` mit `required_permission`. Greift bewusst **nicht** bei Bearer-Tokens — dort ersetzen Scopes die User-Permissions, genau wie bei `checkStructurePerm()`. Admins sind nicht betroffen, `rex_user::hasPerm()` liefert für sie immer `true`.
 - **Testvoraussetzung:** Die zugehörigen Tests in `BackendApiTest` brauchen `API_TEST_VERSION_PLUGIN=1` **und** einen eingeschränkten User mit `structure`- und `modules`-Rechten, aber ohne `version[live_version]`. Fehlt eines von beidem, überspringen sie sich — ein `403` ohne diese Rechte käme aus den Kategorie- oder Modulrechten und würde die Revisionsprüfung nicht belegen.
+
+### Chunked Upload (`lib/RoutePackage/MediaUpload.php`)
+
+Grosse Dateien werden ueber mehrere Requests uebertragen und erst am Ende in den Medienpool gelegt. Wichtig fuer Aenderungen daran:
+
+- **Kein zweiter Weg ins Medienverzeichnis.** `finalize` uebergibt die zusammengesetzte Datei an `rex_media_service::addMedia()` als `file.path`. Der Service akzeptiert das neben `tmp_name` (`mediapool/lib/service_media.php:35`) und verschiebt mit `rex_file::move()`, nicht mit `move_uploaded_file()` (`:88`) — dieselbe Mechanik nutzt die Sync-Seite des Medienpools. Damit greifen Endungs-Blockliste, MIME-Allowlist, `rex_mediapool::filename()`, `sanitizeMedia()` und die EPs `MEDIA_ADD_FILE`/`MEDIA_ADDED` unveraendert. Diese Logik darf hier nicht nachgebaut werden.
+- **Registrierung vor `Backend\Media`.** `boot.php` registriert `MediaUpload` direkt nach `Media`; der Backend-Spiegel klont alle Routen mit Scope-Prefix `media/` und muss die Upload-Routen dabei schon sehen.
+- **Zustand im Dateisystem, nicht in der DB.** Ein Verzeichnis je `upload_id` unter `rex_path::addonData('api', 'upload/')` mit `manifest.json` und `chunk_<index>`. Kein Schema-Update noetig; das Verzeichnis ist per `.htaccess` gesperrt. Bei mehreren Webheads auf gemeinsamer DB, aber getrenntem Dateisystem funktioniert das nicht — dann waere eine Tabelle noetig.
+- **Besitzerbindung.** `manifest.owner` haelt `user:<login>` oder `token:<id>`; fremde Aufrufer erhalten `404`, nicht `403` — die Existenz eines Uploads soll nicht bestaetigt werden.
+- **Zwei Schranken gegen Path Traversal.** Die Route-Requirement `[a-f0-9]{32}` und zusaetzlich `uploadDir()`, das dieselbe Form erneut prueft.
+- **Rechte doppelt pruefen.** `checkMediaPerm()` laeuft bei `init` und erneut bei `finalize`, weil zwischen beiden Requests Zeit liegt.
+- **Aufraeumen ohne Cronjob.** `collectGarbage()` laeuft bei jedem `init` und verwirft Uploads, die aelter als `Ttl` sind.
 
 ### Service-Klassen
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Spalten: **Status** = Endpoint implementiert · **Test** = Bearer-API-Test vorha
 | /api/media                                     | GET       | Medienliste                     | ✅      | ✅    | ✅       | ✅            |
 | /api/media                                     | POST      | Medium anlegen (multipart)      | ✅      | ✅    | ✅       | ✅            |
 | /api/media/{filename}/info                     | GET       | Mediametadaten                  | ✅      | ✅    | ✅       | ✅            |
+| /api/media/upload                              | POST      | Chunked Upload starten          | ✅      | ✅    | ✅       | ✅            |
+| /api/media/upload/{upload_id}                  | GET       | Chunked Upload: Stand           | ✅      | ✅    | ✅       | ✅            |
+| /api/media/upload/{upload_id}/chunk/{index}    | POST/PUT  | Chunked Upload: Chunk senden    | ✅      | ✅    | ✅       | ✅            |
+| /api/media/upload/{upload_id}/finalize         | POST      | Chunked Upload abschliessen     | ✅      | ✅    | ✅       | ✅            |
+| /api/media/upload/{upload_id}                  | DELETE    | Chunked Upload abbrechen        | ✅      | ✅    | ✅       | ✅            |
 | /api/media/{filename}/update                   | PUT/PATCH | Medium ändern                   | ✅      | ✅    | ✅       | ✅            |
 | /api/media/{filename}/delete                   | DELETE    | Medium löschen                  | ✅      | ✅    | ✅       | ✅            |
 | /api/media/{filename}/file                     | GET       | Mediafile (raw)                 | ✅      | ✅    | ✅       | ✅            |
@@ -239,6 +244,39 @@ Beispiel:
 ```
 
 Wer regelmäßig größere Dateien überträgt, erhöht die Limits in der `php.ini` — oder wartet auf die Chunked-Upload-Endpunkte (Issue #39).
+
+### Große Dateien: Chunked Upload
+
+`POST /api/media` ist an `upload_max_filesize` und `post_max_size` gebunden. Größere Dateien gehen stückweise über vier Endpunkte — das Anlegen selbst erledigt danach derselbe Core-Service wie beim normalen Upload, es entsteht also kein zweiter Weg ins Medienverzeichnis.
+
+```
+1. POST   /api/media/upload
+          { "filename": "video.mp4", "size": 524288000, "category_id": 3, "title": "…" }
+          → 201 { "upload_id": "…", "chunk_size_max": 2031616, "expires_at": "…" }
+
+2. POST   /api/media/upload/{upload_id}/chunk/{index}
+          Body: die Chunk-Bytes (application/octet-stream)
+          → 200 { "bytes_received": …, "bytes_missing": … }
+
+3. GET    /api/media/upload/{upload_id}
+          → 200 { "chunks": [0,1,2], "complete": false, "bytes_missing": … }
+
+4. POST   /api/media/upload/{upload_id}/finalize
+          → 201 { "filename": "video.mp4" }
+```
+
+Wissenswertes:
+
+- **Chunkgröße**: `chunk_size_max` aus der Init-Antwort ist die kleinere der beiden PHP-Grenzen minus Reserve. Kleinere Chunks sind immer erlaubt.
+- **Index** ist nullbasiert und muss lückenlos bei `0` beginnen. Derselbe Index erneut gesendet **ersetzt** den Chunk — damit ist ein Wiederholen nach Verbindungsabbruch möglich.
+- **Fortsetzen**: `GET` liefert die bereits angekommenen Indizes; der Client sendet nur den Rest.
+- **Abbrechen**: `DELETE /api/media/upload/{upload_id}` verwirft die Teile.
+- **Grenzen**: höchstens 2 GiB pro Datei und 20 000 Chunks. Die bei `init` angekündigte Größe ist verbindlich — mehr Bytes werden abgewiesen, weniger verhindern das Abschließen.
+- **Verfall**: ein begonnener Upload wird nach 24 Stunden verworfen; aufgeräumt wird beim nächsten `init`.
+- **Bindung an den Aufrufer**: ein Upload ist nur für das Token beziehungsweise den Backend-User sichtbar, der ihn begonnen hat. Fremde Zugriffe erhalten `404`.
+- Die Endung wird bereits bei `init` geprüft, damit ein unerlaubter Dateityp nicht erst nach der Übertragung auffällt.
+
+Chunks liegen bis zum Abschluss unter `redaxo/data/addons/api/upload/` und sind über den Webserver nicht erreichbar.
 
 ### Medien suchen und filtern
 

--- a/boot.php
+++ b/boot.php
@@ -12,6 +12,7 @@ use FriendsOfRedaxo\Api\RoutePackage\Backend\Users as BackendUsers;
 use FriendsOfRedaxo\Api\RoutePackage\Clangs;
 use FriendsOfRedaxo\Api\RoutePackage\Discovery;
 use FriendsOfRedaxo\Api\RoutePackage\Media;
+use FriendsOfRedaxo\Api\RoutePackage\MediaUpload;
 use FriendsOfRedaxo\Api\RoutePackage\Metainfo;
 use FriendsOfRedaxo\Api\RoutePackage\Modules;
 use FriendsOfRedaxo\Api\RoutePackage\Structure;
@@ -23,6 +24,8 @@ RouteCollection::registerRoutePackage(new Modules());
 RouteCollection::registerRoutePackage(new Structure());
 RouteCollection::registerRoutePackage(new Templates());
 RouteCollection::registerRoutePackage(new Media());
+// vor BackendMedia registrieren: der Backend-Spiegel klont alle Routen mit Scope-Prefix media/
+RouteCollection::registerRoutePackage(new MediaUpload());
 RouteCollection::registerRoutePackage(new Users());
 RouteCollection::registerRoutePackage(new Metainfo());
 RouteCollection::registerRoutePackage(new Discovery());

--- a/lib/RoutePackage/MediaUpload.php
+++ b/lib/RoutePackage/MediaUpload.php
@@ -1,0 +1,649 @@
+<?php
+
+namespace FriendsOfRedaxo\Api\RoutePackage;
+
+use Exception;
+use FriendsOfRedaxo\Api\Auth\BearerAuth;
+use FriendsOfRedaxo\Api\RouteCollection;
+use FriendsOfRedaxo\Api\RoutePackage;
+use InvalidArgumentException;
+use rex;
+use rex_dir;
+use rex_file;
+use rex_media_category;
+use rex_media_service;
+use rex_mediapool;
+use rex_path;
+use rex_user;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Route;
+
+use function count;
+use function is_array;
+use function strlen;
+
+use const JSON_PRETTY_PRINT;
+use const UPLOAD_ERR_OK;
+
+/**
+ * Chunked Upload: eine Datei in mehreren Requests uebertragen und erst am Ende
+ * in den Medienpool legen.
+ *
+ * Das Anlegen selbst bleibt vollstaendig Core: `finalize` uebergibt die
+ * zusammengesetzte Datei an rex_media_service::addMedia() als `file.path`.
+ * Der Service verschiebt mit rex_file::move() und nicht mit move_uploaded_file()
+ * (mediapool/lib/service_media.php:88) -- genauso wie die Sync-Seite des
+ * Medienpools. Damit greifen Endungs-Blockliste, MIME-Allowlist,
+ * rex_mediapool::filename(), sanitizeMedia() und die EPs MEDIA_ADD_FILE und
+ * MEDIA_ADDED unveraendert. Es entsteht kein zweiter Pfad ins Medienverzeichnis.
+ */
+class MediaUpload extends RoutePackage
+{
+    /** Groesste Datei, die in Summe ueber alle Chunks entstehen darf. */
+    public const MaxTotalSize = 2147483648; // 2 GiB
+
+    /** Obergrenze fuer den Chunk-Index, damit ein Client kein Verzeichnis flutet. */
+    public const MaxChunks = 20000;
+
+    /** Nach dieser Zeit gilt ein begonnener Upload als verwaist und wird aufgeraeumt. */
+    public const Ttl = 86400; // 24 Stunden
+
+    public function loadRoutes(): void
+    {
+        // Upload beginnen ✅
+        RouteCollection::registerRoute(
+            'media/upload/init',
+            new Route(
+                'media/upload',
+                [
+                    '_controller' => 'FriendsOfRedaxo\Api\RoutePackage\MediaUpload::handleInit',
+                    'Body' => [
+                        'filename' => [
+                            'type' => 'string',
+                            'required' => true,
+                            'default' => null,
+                        ],
+                        'size' => [
+                            'type' => 'int',
+                            'required' => true,
+                            'default' => null,
+                        ],
+                        'category_id' => [
+                            'type' => 'int',
+                            'required' => false,
+                            'default' => 0,
+                        ],
+                        'title' => [
+                            'type' => 'string',
+                            'required' => false,
+                            'default' => '',
+                        ],
+                    ],
+                ],
+                [],
+                [],
+                '',
+                [],
+                ['POST']),
+            'Start a chunked upload. Returns an upload_id and the maximum size per chunk.',
+            null,
+            new BearerAuth(),
+        );
+
+        // Stand des Uploads ✅
+        RouteCollection::registerRoute(
+            'media/upload/status',
+            new Route(
+                'media/upload/{upload_id}',
+                ['_controller' => 'FriendsOfRedaxo\Api\RoutePackage\MediaUpload::handleStatus'],
+                ['upload_id' => '[a-f0-9]{32}'],
+                [],
+                '',
+                [],
+                ['GET']),
+            'Status of a chunked upload: which chunks arrived, how many bytes are missing.',
+            null,
+            new BearerAuth(),
+        );
+
+        // Einzelnen Chunk uebertragen ✅
+        RouteCollection::registerRoute(
+            'media/upload/chunk',
+            new Route(
+                'media/upload/{upload_id}/chunk/{index}',
+                [
+                    '_controller' => 'FriendsOfRedaxo\Api\RoutePackage\MediaUpload::handleChunk',
+                    'Body' => [
+                        'chunk' => [
+                            'type' => 'file',
+                            'required' => false,
+                            'description' => 'Chunk-Daten. Alternativ direkt als Request-Body (application/octet-stream).',
+                        ],
+                    ],
+                ],
+                [
+                    'upload_id' => '[a-f0-9]{32}',
+                    'index' => '\d+',
+                ],
+                [],
+                '',
+                [],
+                ['POST', 'PUT']),
+            'Send one chunk. Index is zero-based; sending the same index again replaces it.',
+            null,
+            new BearerAuth(),
+        );
+
+        // Upload abschliessen ✅
+        RouteCollection::registerRoute(
+            'media/upload/finalize',
+            new Route(
+                'media/upload/{upload_id}/finalize',
+                ['_controller' => 'FriendsOfRedaxo\Api\RoutePackage\MediaUpload::handleFinalize'],
+                ['upload_id' => '[a-f0-9]{32}'],
+                [],
+                '',
+                [],
+                ['POST']),
+            'Assemble the chunks and add the file to the media pool.',
+            null,
+            new BearerAuth(),
+        );
+
+        // Upload abbrechen ✅
+        RouteCollection::registerRoute(
+            'media/upload/delete',
+            new Route(
+                'media/upload/{upload_id}',
+                ['_controller' => 'FriendsOfRedaxo\Api\RoutePackage\MediaUpload::handleAbort'],
+                ['upload_id' => '[a-f0-9]{32}'],
+                [],
+                '',
+                [],
+                ['DELETE']),
+            'Abort a chunked upload and discard the chunks already received.',
+            null,
+            new BearerAuth(),
+        );
+    }
+
+    /** @api */
+    public static function handleInit($Parameter, array $Route = []): Response
+    {
+        $Data = json_decode(rex::getRequest()->getContent(), true);
+        if (!is_array($Data)) {
+            return new JsonResponse(['error' => 'Invalid input'], 400);
+        }
+
+        try {
+            $Data = RouteCollection::getQuerySet($Data, $Parameter['Body'], true);
+        } catch (InvalidArgumentException $e) {
+            // Strikte Pruefung: unbekannte Felder sind keine fehlenden Pflichtfelder.
+            return new JsonResponse(['error' => $e->getMessage()], 400);
+        } catch (Exception $e) {
+            return new JsonResponse(['error' => 'Body field: `' . $e->getMessage() . '` is required'], 400);
+        }
+
+        $filename = trim((string) $Data['filename']);
+        $size = (int) $Data['size'];
+        $categoryId = (int) $Data['category_id'];
+
+        if ('' === $filename) {
+            return new JsonResponse(['error' => 'filename must not be empty'], 400);
+        }
+
+        // Die Endung schon hier pruefen und nicht erst beim Zusammensetzen: sonst
+        // bricht der Upload erst ab, nachdem die ganze Datei uebertragen wurde.
+        if (!rex_mediapool::isAllowedExtension($filename)) {
+            return new JsonResponse([
+                'error' => 'File extension is not allowed',
+                'filename' => $filename,
+            ], 400);
+        }
+
+        if (1 > $size) {
+            return new JsonResponse(['error' => 'size must be greater than 0'], 400);
+        }
+        if ($size > self::MaxTotalSize) {
+            return new JsonResponse([
+                'error' => 'File too large for chunked upload',
+                'size' => $size,
+                'max_total_size' => self::MaxTotalSize,
+            ], 413);
+        }
+
+        $user = RouteCollection::getBackendUser($Route);
+        $permResponse = self::checkMediaPerm($user, $categoryId);
+        if (null !== $permResponse) {
+            return $permResponse;
+        }
+
+        if (0 !== $categoryId && !rex_media_category::get($categoryId)) {
+            return new JsonResponse(['error' => 'Category not found'], 404);
+        }
+
+        self::collectGarbage();
+
+        $uploadId = bin2hex(random_bytes(16));
+        $dir = self::uploadDir($uploadId);
+
+        if (!rex_dir::create($dir)) {
+            return new JsonResponse(['error' => 'Could not create upload directory'], 500);
+        }
+
+        $manifest = [
+            'upload_id' => $uploadId,
+            'filename' => $filename,
+            'size' => $size,
+            'category_id' => $categoryId,
+            'title' => (string) $Data['title'],
+            'owner' => self::ownerKey($Route),
+            'created' => time(),
+        ];
+
+        if (!self::writeManifest($uploadId, $manifest)) {
+            rex_dir::delete($dir);
+            return new JsonResponse(['error' => 'Could not store upload manifest'], 500);
+        }
+
+        return new JsonResponse([
+            'message' => 'Upload started',
+            'upload_id' => $uploadId,
+            'filename' => $filename,
+            'size' => $size,
+            'chunk_size_max' => self::maxChunkSize(),
+            'max_chunks' => self::MaxChunks,
+            'expires_at' => date('c', $manifest['created'] + self::Ttl),
+        ], 201);
+    }
+
+    /** @api */
+    public static function handleStatus($Parameter, array $Route = []): Response
+    {
+        $uploadId = (string) $Parameter['upload_id'];
+        $manifest = self::loadManifest($uploadId);
+        if (null === $manifest) {
+            return new JsonResponse(['error' => 'Upload not found'], 404);
+        }
+        if (!self::isOwner($manifest, $Route)) {
+            return new JsonResponse(['error' => 'Upload not found'], 404);
+        }
+
+        $chunks = self::chunkSizes($uploadId);
+        $received = array_sum($chunks);
+        $indices = array_keys($chunks);
+        sort($indices);
+
+        return new JsonResponse(json_encode([
+            'upload_id' => $uploadId,
+            'filename' => $manifest['filename'],
+            'size' => (int) $manifest['size'],
+            'bytes_received' => $received,
+            'bytes_missing' => max(0, (int) $manifest['size'] - $received),
+            'chunks' => $indices,
+            'contiguous' => self::isContiguous($indices),
+            'complete' => $received === (int) $manifest['size'] && self::isContiguous($indices),
+            'expires_at' => date('c', (int) $manifest['created'] + self::Ttl),
+        ], JSON_PRETTY_PRINT), 200, [], true);
+    }
+
+    /** @api */
+    public static function handleChunk($Parameter, array $Route = []): Response
+    {
+        $uploadId = (string) $Parameter['upload_id'];
+        $index = (int) $Parameter['index'];
+
+        $manifest = self::loadManifest($uploadId);
+        if (null === $manifest || !self::isOwner($manifest, $Route)) {
+            return new JsonResponse(['error' => 'Upload not found'], 404);
+        }
+
+        if ($index >= self::MaxChunks) {
+            return new JsonResponse([
+                'error' => 'Chunk index out of range',
+                'max_chunks' => self::MaxChunks,
+            ], 400);
+        }
+
+        $data = self::readChunkPayload();
+        if ('' === $data) {
+            return new JsonResponse(['error' => 'Empty chunk'], 400);
+        }
+
+        // Bereits vorhandene Chunks zaehlen ohne den, der jetzt ersetzt wird --
+        // ein erneut gesendeter Index darf die Summe nicht doppelt belasten.
+        $sizes = self::chunkSizes($uploadId);
+        unset($sizes[$index]);
+        $total = array_sum($sizes) + strlen($data);
+
+        if ($total > (int) $manifest['size']) {
+            return new JsonResponse([
+                'error' => 'Chunks exceed the size announced at init',
+                'size' => (int) $manifest['size'],
+                'would_be' => $total,
+            ], 400);
+        }
+
+        if (false === rex_file::put(self::chunkPath($uploadId, $index), $data)) {
+            return new JsonResponse(['error' => 'Could not store chunk'], 500);
+        }
+
+        return new JsonResponse([
+            'message' => 'Chunk stored',
+            'upload_id' => $uploadId,
+            'index' => $index,
+            'bytes_stored' => strlen($data),
+            'bytes_received' => $total,
+            'bytes_missing' => max(0, (int) $manifest['size'] - $total),
+        ], 200);
+    }
+
+    /** @api */
+    public static function handleFinalize($Parameter, array $Route = []): Response
+    {
+        $uploadId = (string) $Parameter['upload_id'];
+
+        $manifest = self::loadManifest($uploadId);
+        if (null === $manifest || !self::isOwner($manifest, $Route)) {
+            return new JsonResponse(['error' => 'Upload not found'], 404);
+        }
+
+        // Rechte erneut pruefen: zwischen init und finalize kann sich die
+        // Berechtigung geaendert haben.
+        $categoryId = (int) $manifest['category_id'];
+        $user = RouteCollection::getBackendUser($Route);
+        $permResponse = self::checkMediaPerm($user, $categoryId);
+        if (null !== $permResponse) {
+            return $permResponse;
+        }
+
+        $sizes = self::chunkSizes($uploadId);
+        $indices = array_keys($sizes);
+        sort($indices);
+
+        if (0 === count($indices)) {
+            return new JsonResponse(['error' => 'No chunks received'], 400);
+        }
+        if (!self::isContiguous($indices)) {
+            return new JsonResponse([
+                'error' => 'Missing chunks: the received indices are not contiguous starting at 0',
+                'chunks' => $indices,
+            ], 400);
+        }
+
+        $received = array_sum($sizes);
+        if ($received !== (int) $manifest['size']) {
+            return new JsonResponse([
+                'error' => 'Assembled size does not match the size announced at init',
+                'size' => (int) $manifest['size'],
+                'bytes_received' => $received,
+            ], 400);
+        }
+
+        $assembled = self::uploadDir($uploadId) . 'assembled';
+        if (!self::assemble($uploadId, $indices, $assembled)) {
+            rex_file::delete($assembled);
+            return new JsonResponse(['error' => 'Could not assemble the chunks'], 500);
+        }
+
+        try {
+            $result = rex_media_service::addMedia([
+                'category_id' => $categoryId,
+                'title' => (string) $manifest['title'],
+                'file' => [
+                    'name' => (string) $manifest['filename'],
+                    'path' => $assembled,
+                ],
+            ], true);
+        } catch (Exception $e) {
+            rex_file::delete($assembled);
+            return new JsonResponse(['error' => $e->getMessage()], 400);
+        }
+
+        // addMedia() verschiebt die Datei; bleibt sie liegen, war der Aufruf erfolglos.
+        rex_file::delete($assembled);
+        rex_dir::delete(self::uploadDir($uploadId));
+
+        if (empty($result['ok'])) {
+            return new JsonResponse(['error' => $result['msg'] ?? 'Unknown error'], 400);
+        }
+
+        return new JsonResponse([
+            'message' => 'Media created',
+            'filename' => $result['filename'],
+        ], 201);
+    }
+
+    /** @api */
+    public static function handleAbort($Parameter, array $Route = []): Response
+    {
+        $uploadId = (string) $Parameter['upload_id'];
+
+        $manifest = self::loadManifest($uploadId);
+        if (null === $manifest || !self::isOwner($manifest, $Route)) {
+            return new JsonResponse(['error' => 'Upload not found'], 404);
+        }
+
+        rex_dir::delete(self::uploadDir($uploadId));
+
+        return new JsonResponse(['message' => 'Upload aborted', 'upload_id' => $uploadId], 200);
+    }
+
+    // =====================================================================
+    // Internals
+    // =====================================================================
+
+    /**
+     * Chunk-Daten aus dem Request: bevorzugt der rohe Body
+     * (application/octet-stream), alternativ ein Multipart-Feld `chunk`, damit
+     * der Endpunkt auch aus Swagger UI heraus bedienbar ist.
+     */
+    private static function readChunkPayload(): string
+    {
+        if (isset($_FILES['chunk']['tmp_name']) && '' !== $_FILES['chunk']['tmp_name'] && UPLOAD_ERR_OK === (int) $_FILES['chunk']['error']) {
+            $content = file_get_contents($_FILES['chunk']['tmp_name']);
+            return false === $content ? '' : $content;
+        }
+
+        return rex::getRequest()->getContent();
+    }
+
+    private static function baseDir(): string
+    {
+        return rex_path::addonData('api', 'upload/');
+    }
+
+    private static function uploadDir(string $uploadId): string
+    {
+        // Der Aufrufer liefert die Id ausschliesslich ueber die Route-Requirement
+        // [a-f0-9]{32}; der Test hier ist die zweite Schranke gegen Path Traversal.
+        if (1 !== preg_match('/^[a-f0-9]{32}$/', $uploadId)) {
+            return self::baseDir() . 'invalid/';
+        }
+        return self::baseDir() . $uploadId . '/';
+    }
+
+    private static function chunkPath(string $uploadId, int $index): string
+    {
+        return self::uploadDir($uploadId) . 'chunk_' . $index;
+    }
+
+    /**
+     * @param array<string, mixed> $manifest
+     */
+    private static function writeManifest(string $uploadId, array $manifest): bool
+    {
+        return false !== rex_file::put(self::uploadDir($uploadId) . 'manifest.json', json_encode($manifest));
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private static function loadManifest(string $uploadId): ?array
+    {
+        $content = rex_file::get(self::uploadDir($uploadId) . 'manifest.json');
+        if (null === $content) {
+            return null;
+        }
+        $manifest = json_decode($content, true);
+        return is_array($manifest) ? $manifest : null;
+    }
+
+    /**
+     * Groesse je vorhandenem Chunk, indiziert nach Chunk-Nummer.
+     *
+     * @return array<int, int>
+     */
+    private static function chunkSizes(string $uploadId): array
+    {
+        $sizes = [];
+        foreach (glob(self::uploadDir($uploadId) . 'chunk_*') ?: [] as $path) {
+            if (1 === preg_match('/chunk_(\d+)$/', $path, $match)) {
+                $sizes[(int) $match[1]] = (int) filesize($path);
+            }
+        }
+        return $sizes;
+    }
+
+    /**
+     * @param list<int> $indices aufsteigend sortiert
+     */
+    private static function isContiguous(array $indices): bool
+    {
+        foreach ($indices as $position => $index) {
+            if ($index !== $position) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @param list<int> $indices
+     */
+    private static function assemble(string $uploadId, array $indices, string $target): bool
+    {
+        $out = fopen($target, 'wb');
+        if (false === $out) {
+            return false;
+        }
+
+        try {
+            foreach ($indices as $index) {
+                $in = fopen(self::chunkPath($uploadId, $index), 'rb');
+                if (false === $in) {
+                    return false;
+                }
+                $copied = stream_copy_to_stream($in, $out);
+                fclose($in);
+                if (false === $copied) {
+                    return false;
+                }
+            }
+        } finally {
+            fclose($out);
+        }
+
+        return true;
+    }
+
+    /**
+     * Bindet den Upload an den Aufrufer, damit ein fremdes Token mit geratener
+     * Id nichts anfangen kann.
+     */
+    private static function ownerKey(array $Route): string
+    {
+        $auth = $Route['authorization'] ?? null;
+        $object = null === $auth ? null : $auth->getAuthorizationObject();
+
+        if ($object instanceof rex_user) {
+            return 'user:' . $object->getLogin();
+        }
+        if (null !== $object && method_exists($object, 'getId')) {
+            return 'token:' . (string) $object->getId();
+        }
+        return 'anonymous';
+    }
+
+    /**
+     * @param array<string, mixed> $manifest
+     */
+    private static function isOwner(array $manifest, array $Route): bool
+    {
+        return ($manifest['owner'] ?? null) === self::ownerKey($Route);
+    }
+
+    /** Verwaiste Uploads aufraeumen -- ohne Cronjob, beim Beginn eines neuen Uploads. */
+    private static function collectGarbage(): void
+    {
+        $deadline = time() - self::Ttl;
+
+        foreach (glob(self::baseDir() . '*', GLOB_ONLYDIR) ?: [] as $dir) {
+            $manifest = rex_file::get(rtrim($dir, '/') . '/manifest.json');
+            if (null === $manifest) {
+                // Kein Manifest: nur aufraeumen, wenn das Verzeichnis selbst alt ist.
+                if (filemtime($dir) < $deadline) {
+                    rex_dir::delete($dir);
+                }
+                continue;
+            }
+            $decoded = json_decode($manifest, true);
+            $created = is_array($decoded) ? (int) ($decoded['created'] ?? 0) : 0;
+            if ($created < $deadline) {
+                rex_dir::delete($dir);
+            }
+        }
+    }
+
+    /**
+     * Was pro Chunk-Request tatsaechlich durchgeht -- die kleinere der beiden
+     * PHP-Grenzen, mit Reserve fuer Header und Multipart-Rahmen.
+     */
+    private static function maxChunkSize(): int
+    {
+        $post = self::iniBytes((string) ini_get('post_max_size'));
+        $upload = self::iniBytes((string) ini_get('upload_max_filesize'));
+
+        $limits = array_filter([$post, $upload], static fn(int $v): bool => $v > 0);
+        if (0 === count($limits)) {
+            return 1048576;
+        }
+
+        $limit = min($limits);
+        return max(65536, $limit - 65536);
+    }
+
+    private static function iniBytes(string $value): int
+    {
+        $value = trim($value);
+        if ('' === $value) {
+            return 0;
+        }
+        $number = (int) $value;
+        return match (strtolower(substr($value, -1))) {
+            'g' => $number * 1024 * 1024 * 1024,
+            'm' => $number * 1024 * 1024,
+            'k' => $number * 1024,
+            default => $number,
+        };
+    }
+
+    private static function checkMediaPerm(?rex_user $user, ?int $categoryId = null): ?Response
+    {
+        if (null === $user) {
+            return null;
+        }
+        if ($user->isAdmin()) {
+            return null;
+        }
+        $perm = $user->getComplexPerm('media');
+        if (null !== $categoryId && !$perm->hasCategoryPerm($categoryId)) {
+            return new JsonResponse(['error' => 'Permission denied'], 403);
+        }
+        if (null === $categoryId && !$perm->hasAll()) {
+            return new JsonResponse(['error' => 'Permission denied'], 403);
+        }
+        return null;
+    }
+}

--- a/tests/ApiTestCase.php
+++ b/tests/ApiTestCase.php
@@ -97,6 +97,14 @@ abstract class ApiTestCase extends TestCase
     }
 
     /**
+     * Sendet einen rohen Body (application/octet-stream) -- fuer Chunk-Uploads.
+     */
+    protected function postRaw(string $endpoint, string $body): array
+    {
+        return $this->request('POST', $endpoint, ['raw' => $body]);
+    }
+
+    /**
      * Führt einen HTTP-Request aus.
      */
     protected function request(string $method, string $endpoint, array $options = []): array
@@ -130,6 +138,14 @@ abstract class ApiTestCase extends TestCase
                 'Authorization: Bearer ' . self::$apiToken,
                 'Accept: application/json',
                 'Content-Type: application/json',
+            ]);
+        } elseif (isset($options['raw'])) {
+            // Roher Body, z.B. Chunk-Daten als application/octet-stream
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $options['raw']);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, [
+                'Authorization: Bearer ' . self::$apiToken,
+                'Accept: application/json',
+                'Content-Type: application/octet-stream',
             ]);
         } elseif (isset($options['multipart']) && $options['multipart']) {
             $postData = $options['data'] ?? [];

--- a/tests/MediaUploadApiTest.php
+++ b/tests/MediaUploadApiTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfRedaxo\Api\Tests;
+
+/**
+ * Tests für den Chunked Upload (`media/upload/*`).
+ *
+ * Voraussetzungen am API-Token:
+ *   media/upload/init, media/upload/status, media/upload/chunk,
+ *   media/upload/finalize, media/upload/delete
+ *
+ * Fehlt einer dieser Scopes, überspringen sich die Tests statt fehlzuschlagen.
+ */
+class MediaUploadApiTest extends ApiTestCase
+{
+    /** Nutzlast, die in mehrere Chunks zerlegt wird. */
+    private const PayloadBytes = 300000;
+
+    public function testChunkedUploadRoundtrip(): void
+    {
+        $payload = self::pngPayload(self::PayloadBytes);
+        $upload = $this->initUpload('chunked-roundtrip.png', strlen($payload));
+
+        $chunks = str_split($payload, 100000);
+        $this->assertGreaterThan(1, count($chunks), 'Die Nutzlast muss in mehrere Chunks fallen.');
+
+        foreach ($chunks as $index => $chunk) {
+            $response = $this->postRaw('media/upload/' . $upload['upload_id'] . '/chunk/' . $index, $chunk);
+            $this->assertSuccess($response);
+        }
+
+        $status = $this->get('media/upload/' . $upload['upload_id']);
+        $this->assertSuccess($status);
+        $this->assertSame(range(0, count($chunks) - 1), $status['data']['chunks']);
+        $this->assertTrue($status['data']['complete']);
+        $this->assertSame(0, $status['data']['bytes_missing']);
+
+        $finalize = $this->post('media/upload/' . $upload['upload_id'] . '/finalize');
+        $this->assertStatus(201, $finalize);
+        $filename = $finalize['data']['filename'];
+        $this->trackResource('media', $filename . '/delete');
+
+        // Die abgelegte Datei muss genau so groß sein wie die Nutzlast -- sonst wurden
+        // Chunks in falscher Reihenfolge oder doppelt zusammengesetzt.
+        $info = $this->get('media/' . $filename . '/info');
+        $this->assertSuccess($info);
+        $this->assertSame(strlen($payload), (int) $info['data']['filesize']);
+
+        // Nach dem Abschluss darf der Upload nicht mehr auffindbar sein.
+        $gone = $this->get('media/upload/' . $upload['upload_id']);
+        $this->assertStatus(404, $gone);
+    }
+
+    public function testInitRejectsDisallowedExtension(): void
+    {
+        $response = $this->post('media/upload', ['filename' => 'evil.php', 'size' => 100]);
+        if (401 === $response['status']) {
+            $this->markTestSkipped('Dem Token fehlt der Scope media/upload/init.');
+        }
+
+        $this->assertStatus(400, $response);
+        $this->assertSame('File extension is not allowed', $response['data']['error']);
+    }
+
+    public function testInitRejectsUnknownBodyField(): void
+    {
+        $response = $this->post('media/upload', ['filename' => 'a.png', 'size' => 100, 'foo' => 1]);
+        if (401 === $response['status']) {
+            $this->markTestSkipped('Dem Token fehlt der Scope media/upload/init.');
+        }
+
+        $this->assertStatus(400, $response);
+        $this->assertStringContainsString('Unknown field', (string) $response['data']['error']);
+    }
+
+    public function testInitRejectsInvalidSize(): void
+    {
+        $zero = $this->post('media/upload', ['filename' => 'a.png', 'size' => 0]);
+        if (401 === $zero['status']) {
+            $this->markTestSkipped('Dem Token fehlt der Scope media/upload/init.');
+        }
+        $this->assertStatus(400, $zero);
+
+        $huge = $this->post('media/upload', ['filename' => 'a.png', 'size' => 9999999999]);
+        $this->assertStatus(413, $huge);
+        $this->assertArrayHasKey('max_total_size', $huge['data']);
+    }
+
+    public function testChunksMayNotExceedAnnouncedSize(): void
+    {
+        $upload = $this->initUpload('too-big.png', 200);
+
+        try {
+            $ok = $this->postRaw('media/upload/' . $upload['upload_id'] . '/chunk/0', str_repeat('x', 100));
+            $this->assertSuccess($ok);
+
+            $tooBig = $this->postRaw('media/upload/' . $upload['upload_id'] . '/chunk/1', str_repeat('x', 500));
+            $this->assertStatus(400, $tooBig);
+
+            // Der abgelehnte Chunk darf nicht gespeichert worden sein.
+            $status = $this->get('media/upload/' . $upload['upload_id']);
+            $this->assertSame([0], $status['data']['chunks']);
+            $this->assertSame(100, $status['data']['bytes_received']);
+        } finally {
+            $this->delete('media/upload/' . $upload['upload_id']);
+        }
+    }
+
+    public function testResendingSameChunkReplacesItInsteadOfAdding(): void
+    {
+        $upload = $this->initUpload('replace.png', 200);
+
+        try {
+            $first = $this->postRaw('media/upload/' . $upload['upload_id'] . '/chunk/0', str_repeat('x', 100));
+            $this->assertSame(100, $first['data']['bytes_received']);
+
+            $again = $this->postRaw('media/upload/' . $upload['upload_id'] . '/chunk/0', str_repeat('y', 100));
+            $this->assertSuccess($again);
+            $this->assertSame(100, $again['data']['bytes_received'], 'Derselbe Index darf die Summe nicht doppelt belasten.');
+        } finally {
+            $this->delete('media/upload/' . $upload['upload_id']);
+        }
+    }
+
+    public function testFinalizeRejectsGapInChunks(): void
+    {
+        $upload = $this->initUpload('gap.png', 200);
+
+        try {
+            $this->postRaw('media/upload/' . $upload['upload_id'] . '/chunk/0', str_repeat('x', 100));
+            $this->postRaw('media/upload/' . $upload['upload_id'] . '/chunk/2', str_repeat('x', 100));
+
+            $status = $this->get('media/upload/' . $upload['upload_id']);
+            $this->assertFalse($status['data']['contiguous']);
+
+            $finalize = $this->post('media/upload/' . $upload['upload_id'] . '/finalize');
+            $this->assertStatus(400, $finalize);
+            $this->assertStringContainsString('contiguous', (string) $finalize['data']['error']);
+        } finally {
+            $this->delete('media/upload/' . $upload['upload_id']);
+        }
+    }
+
+    public function testFinalizeRejectsSizeMismatch(): void
+    {
+        $upload = $this->initUpload('short.png', 300);
+
+        try {
+            $this->postRaw('media/upload/' . $upload['upload_id'] . '/chunk/0', str_repeat('x', 100));
+
+            $finalize = $this->post('media/upload/' . $upload['upload_id'] . '/finalize');
+            $this->assertStatus(400, $finalize);
+            $this->assertSame(100, $finalize['data']['bytes_received']);
+        } finally {
+            $this->delete('media/upload/' . $upload['upload_id']);
+        }
+    }
+
+    public function testAbortRemovesUpload(): void
+    {
+        $upload = $this->initUpload('abort.png', 200);
+        $this->postRaw('media/upload/' . $upload['upload_id'] . '/chunk/0', str_repeat('x', 100));
+
+        $abort = $this->delete('media/upload/' . $upload['upload_id']);
+        $this->assertSuccess($abort);
+
+        $status = $this->get('media/upload/' . $upload['upload_id']);
+        $this->assertStatus(404, $status);
+    }
+
+    public function testUnknownUploadIdReturnsNotFound(): void
+    {
+        $response = $this->get('media/upload/' . str_repeat('a', 32));
+        if (401 === $response['status']) {
+            $this->markTestSkipped('Dem Token fehlt der Scope media/upload/status.');
+        }
+
+        $this->assertStatus(404, $response);
+        // Auf den Text pruefen, nicht nur auf 404: eine nicht registrierte Route
+        // antwortet ebenfalls mit 404, der Test wuerde sonst nichts zeigen.
+        $this->assertSame('Upload not found', $response['data']['error']);
+    }
+
+    /**
+     * Startet einen Upload und liefert die Antwortdaten, oder überspringt den Test,
+     * wenn dem Token die Scopes fehlen.
+     *
+     * @return array<string, mixed>
+     */
+    private function initUpload(string $filename, int $size): array
+    {
+        $response = $this->post('media/upload', [
+            'filename' => $filename,
+            'size' => $size,
+            'category_id' => 0,
+            'title' => $this->generateTestName('upload'),
+        ]);
+
+        if (401 === $response['status']) {
+            $this->markTestSkipped('Dem Token fehlen die Scopes media/upload/*.');
+        }
+
+        $this->assertStatus(201, $response);
+
+        return $response['data'];
+    }
+
+    /** Gültiges PNG mit tEXt-Ballast, damit die Datei die Zielgröße erreicht. */
+    private static function pngPayload(int $bytes): string
+    {
+        $chunk = static function (string $type, string $data): string {
+            return pack('N', strlen($data)) . $type . $data . pack('N', crc32($type . $data));
+        };
+
+        return "\x89PNG\r\n\x1a\n"
+            . $chunk('IHDR', pack('NNCCCCC', 1, 1, 8, 2, 0, 0, 0))
+            . $chunk('IDAT', gzcompress("\x00\x00\x00\x00"))
+            . $chunk('tEXt', "Comment\x00" . str_repeat('x', $bytes))
+            . $chunk('IEND', '');
+    }
+}


### PR DESCRIPTION
Schließt #39. Fünf Endpunkte unter dem Scope `media/upload/`:

| Endpunkt | Methode | Zweck |
|---|---|---|
| `media/upload` | POST | init — `upload_id`, `chunk_size_max`, `expires_at` |
| `media/upload/{upload_id}` | GET | Stand: welche Indizes da sind, wie viele Bytes fehlen |
| `media/upload/{upload_id}/chunk/{index}` | POST/PUT | ein Chunk, roher Body oder Multipart-Feld `chunk` |
| `media/upload/{upload_id}/finalize` | POST | zusammensetzen und anlegen |
| `media/upload/{upload_id}` | DELETE | abbrechen |

Der Backend-Spiegel entsteht automatisch, weil `MediaUpload` in `boot.php` vor `Backend\Media` registriert wird.

**Kein zweiter Weg ins Medienverzeichnis.** `finalize` übergibt die zusammengesetzte Datei an `rex_media_service::addMedia()` als `file.path` — der Service akzeptiert das neben `tmp_name` (`service_media.php:35`) und verschiebt mit `rex_file::move()` statt `move_uploaded_file()` (`:88`), genau wie die Sync-Seite des Medienpools. Endungs-Blockliste, MIME-Allowlist, `rex_mediapool::filename()`, `sanitizeMedia()` und die EPs `MEDIA_ADD_FILE`/`MEDIA_ADDED` greifen also unverändert.

An der laufenden Installation gemessen (`upload_max_filesize` 2 MB), 5-MB-PNG in sechs Chunks à 1 MB:

```
Kontrolle: POST /api/media mit derselben Datei → 413 (zu groß)
init → 201    chunks 0..5 → bytes_missing 1048576 … 0
status → chunks [0,1,2,3,4,5], complete true
finalize → 201 {"filename":"chunked-test.png"}

Heruntergeladen und verglichen: byte-identisch (sha256 gleich, 5242963 Bytes)
DB-Eintrag: filetype image/png, filesize 5242963, width/height erkannt
```

Durchgemessene Schutzmechanismen: unerlaubte Endung bei `init` (`400`, **vor** der Übertragung), `size` 0 und über 2 GiB, unbekanntes Body-Feld, Chunks über der angekündigten Größe, leerer Chunk, Index über `max_chunks`, Lücke in der Folge und Größenabweichung bei `finalize`, Abbruch, Garbage Collection nach TTL. Die Besitzerbindung habe ich mit einem **zweiten Token samt Scope** geprüft — sonst hätte nur der fehlende Scope geantwortet und der Test nichts gezeigt: eigenes Token `200`, fremdes Token `404`.

10 Tests in `MediaUploadApiTest`, Gegenprobe mit deregistriertem RoutePackage: **alle 10** fallen. Zwei Läufe hintereinander hinterlassen keine Reste im Upload-Verzeichnis.

Suite: **215 Tests, 2508 Assertions, 5 Skips**, keine Fehler.

Zwei Punkte für die Übernahme: das Test-Token braucht die neuen Scopes `media/upload/*` (sonst überspringen sich die Tests), und der Zustand liegt im Dateisystem — bei mehreren Webheads mit getrenntem Dateisystem bräuchte es stattdessen eine Tabelle. Beides steht in CLAUDE.md.

---
*Dieser Text wurde durch eine KI erstellt.*
