### PR TITLE
Chunked Upload: ein Scope statt fünf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ pnpm install && pnpm build
 Tests sind **Integrationstests**, die echte HTTP-Requests via cURL an eine laufende REDAXO-Installation senden. Setup:
 
 1. `cp tests/.env.example tests/.env` und Werte anpassen (Basis-URL, Bearer-Token, Backend-Credentials, existierende IDs).
-2. Bearer-Token im REDAXO-Backend unter `API → Token` anlegen und alle benötigten Scopes vergeben — die Test-Suite erwartet u.a. `structure/articles/slices/{list,add,get,update,delete}`, `system/clangs/*`, `modules/*`, `templates/*`, `users/*`, `media/*` (inklusive `media/upload/*` für `MediaUploadApiTest`), `metainfo/*`.
+2. Bearer-Token im REDAXO-Backend unter `API → Token` anlegen und alle benötigten Scopes vergeben — die Test-Suite erwartet u.a. `structure/articles/slices/{list,add,get,update,delete}`, `system/clangs/*`, `modules/*`, `templates/*`, `users/*`, `media/*` (inklusive `media/upload` für `MediaUploadApiTest`), `metainfo/*`.
 3. Restricted-Backend-User mit eingeschränkten Permissions anlegen (Default-Login `apitest_restricted`):
    ```bash
    redaxo/bin/console user:create apitest_restricted <password> --name="API Test Restricted"
@@ -75,7 +75,7 @@ Jede Datei definiert Routen und Handler-Methoden für eine Ressourcengruppe:
 | `Templates.php`    | Templates CRUD                                         | `templates/`     |
 | `Clangs.php`       | Sprachen CRUD                                          | `system/clangs/` |
 | `Metainfo.php`     | Metainfo-Felddefinitionen + Werte (Artikel/Kategorie/Medium/Sprache) | `metainfo/`      |
-| `MediaUpload.php`  | Chunked Upload (init/chunk/status/finalize/abort)       | `media/upload/`  |
+| `MediaUpload.php`  | Chunked Upload (init/chunk/status/finalize/abort)       | `media/upload`   |
 | `Discovery.php`    | Selbstauskunft `/api/me` (erlaubte Endpunkte, OpenAPI gefiltert)      | — (scope-frei)   |
 
 Die `lib/RoutePackage/Backend/`-Klassen erweitern jeweils ihre Bearer-Variante, klonen alle passenden Routen, hängen `backend/` an Pfad und Scope und ersetzen das Auth-Objekt durch `BackendUser`. Beim Anlegen eines neuen Bearer-Endpunkts entsteht der Backend-Spiegel automatisch — eigene `Backend/*.php`-Implementierungen sind nur nötig, wenn das Standardverhalten überschrieben werden soll (Beispiel: `Backend/Media.php`).
@@ -170,6 +170,7 @@ Grosse Dateien werden ueber mehrere Requests uebertragen und erst am Ende in den
 - **Zwei Schranken gegen Path Traversal.** Die Route-Requirement `[a-f0-9]{32}` und zusaetzlich `uploadDir()`, das dieselbe Form erneut prueft.
 - **Rechte doppelt pruefen.** `checkMediaPerm()` laeuft bei `init` und erneut bei `finalize`, weil zwischen beiden Requests Zeit liegt.
 - **Aufraeumen ohne Cronjob.** `collectGarbage()` laeuft bei jedem `init` und verwirft Uploads, die aelter als `Ttl` sind.
+- **Ein Scope fuer alle fuenf Routen** (`MediaUpload::Scope`). Moeglich durch `Auth::getScope()`: der Routenname bleibt der eindeutige Schluessel in `RouteCollection`, der geforderte Scope ist davon entkoppelt. `new BearerAuth(true, 'scope/name')` setzt ihn. Wer einen mehrstufigen Ablauf ergaenzt, nutzt dasselbe Muster -- einzeln unbrauchbare Endpunkte gehoeren nicht in einzelne Scopes, weil eine Teilvergabe erst mitten im Ablauf auffaellt. `Token::getAvailableScopes()` dedupliziert, damit die Token-Seite eine Checkbox zeigt.
 
 ### Service-Klassen
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Wissenswertes:
 - **Abbrechen**: `DELETE /api/media/upload/{upload_id}` verwirft die Teile.
 - **Grenzen**: höchstens 2 GiB pro Datei und 20 000 Chunks. Die bei `init` angekündigte Größe ist verbindlich — mehr Bytes werden abgewiesen, weniger verhindern das Abschließen.
 - **Verfall**: ein begonnener Upload wird nach 24 Stunden verworfen; aufgeräumt wird beim nächsten `init`.
+- **Ein Scope**: alle fünf Endpunkte laufen über den Scope `media/upload` (Backend: `backend/media/upload`). Einzeln sind sie unbrauchbar, deshalb gibt es dafür nur eine Checkbox auf der Token-Seite.
 - **Bindung an den Aufrufer**: ein Upload ist nur für das Token beziehungsweise den Backend-User sichtbar, der ihn begonnen hat. Fremde Zugriffe erhalten `404`.
 - Die Endung wird bereits bei `init` geprüft, damit ein unerlaubter Dateityp nicht erst nach der Übertragung auffällt.
 

--- a/lib/Auth/Auth.php
+++ b/lib/Auth/Auth.php
@@ -22,6 +22,20 @@ abstract class Auth
         return true;
     }
 
+    /**
+     * Der Scope, der fuer diese Route vergeben sein muss.
+     *
+     * Normalerweise ist das der Routenname -- ein Endpunkt, ein Scope. Mehrere
+     * Routen, die zusammen einen Ablauf bilden (Chunked Upload: init, chunk,
+     * status, finalize, abort), teilen sich dagegen einen Scope: einzeln sind sie
+     * unbrauchbar, und eine Teilvergabe fiele erst mitten im Ablauf auf. Der
+     * Routenname bleibt eindeutig, weil RouteCollection ihn als Schluessel nutzt.
+     */
+    public function getScope(string $routeName): string
+    {
+        return $routeName;
+    }
+
     public function getAuthorizationObject(): mixed
     {
         return null;

--- a/lib/Auth/BearerAuth.php
+++ b/lib/Auth/BearerAuth.php
@@ -18,18 +18,28 @@ class BearerAuth extends Auth
      */
     private bool $requireScope = true;
 
+    /** Gesetzt, wenn mehrere Routen sich einen Scope teilen; sonst gilt der Routenname. */
+    private ?string $scope = null;
+
     /**
      * @param bool $requireScope false: every valid token is authorized, no scope needed (discovery routes)
+     * @param string|null $scope shared scope for several routes; null means the route name
      */
-    public function __construct(bool $requireScope = true)
+    public function __construct(bool $requireScope = true, ?string $scope = null)
     {
         parent::__construct();
         $this->requireScope = $requireScope;
+        $this->scope = $scope;
     }
 
     public function requiresScope(): bool
     {
         return $this->requireScope;
+    }
+
+    public function getScope(string $routeName): string
+    {
+        return $this->scope ?? $routeName;
     }
 
     public function isAuthorized($parameters): bool
@@ -41,7 +51,7 @@ class BearerAuth extends Auth
         if (!$this->requireScope) {
             return true;
         }
-        if (in_array($parameters['_route'], $this->Token->getScopes(), true)) {
+        if (in_array($this->getScope($parameters['_route']), $this->Token->getScopes(), true)) {
             return true;
         }
         return false;

--- a/lib/RouteCollection.php
+++ b/lib/RouteCollection.php
@@ -153,7 +153,7 @@ class RouteCollection
                         // credential is valid, only the scope is missing: name it, so callers can tell
                         // an invalid token from a missing permission
                         if ($AuthObject instanceof BearerAuth && null !== $AuthObject->getAuthorizationObject()) {
-                            $Error['required_scope'] = $parameters['_route'];
+                            $Error['required_scope'] = $AuthObject->getScope($parameters['_route']);
                         }
                         $Response = new JsonResponse($Error, 401);
                     } else {

--- a/lib/RoutePackage/Discovery.php
+++ b/lib/RoutePackage/Discovery.php
@@ -93,7 +93,7 @@ class Discovery extends RoutePackage
                 if (!$RouteAuth instanceof BearerAuth) {
                     continue;
                 }
-                if ($RouteAuth->requiresScope() && !in_array($Scope, $Scopes, true)) {
+                if ($RouteAuth->requiresScope() && !in_array($RouteAuth->getScope((string) $Scope), $Scopes, true)) {
                     continue;
                 }
                 $Allowed[$Scope] = $RouteArray;
@@ -129,7 +129,12 @@ class Discovery extends RoutePackage
 
         $Endpoints = [];
         foreach ($Allowed as $Scope => $RouteArray) {
-            $Endpoints[] = self::describeRoute($Scope, $RouteArray);
+            // Ausgegeben wird der geforderte Scope, nicht der Routenname: bei einem
+            // Ablauf aus mehreren Routen (Chunked Upload) sind das verschiedene Werte,
+            // und ein Client soll den Namen sehen, den er am Token vergeben muss.
+            $RouteAuth = $RouteArray['authorization'] ?? null;
+            $EffectiveScope = null === $RouteAuth ? (string) $Scope : $RouteAuth->getScope((string) $Scope);
+            $Endpoints[] = self::describeRoute($EffectiveScope, $RouteArray);
         }
 
         $Meta['endpoint_count'] = count($Endpoints);

--- a/lib/RoutePackage/Media.php
+++ b/lib/RoutePackage/Media.php
@@ -8,6 +8,7 @@ use FriendsOfRedaxo\Api\ListHelper;
 use FriendsOfRedaxo\Api\RouteCollection;
 use FriendsOfRedaxo\Api\RoutePackage;
 use rex;
+use rex_api_exception;
 use rex_functional_exception;
 use rex_media;
 use rex_media_cache;
@@ -868,6 +869,10 @@ class Media extends RoutePackage
             }
 
             return new JsonResponse(['error' => $result['msg'] ?? 'Unknown error'], 400);
+        } catch (rex_api_exception $e) {
+            // Der Service wirft bei unerlaubter Endung oder unerlaubtem MIME-Typ --
+            // das ist ein Verstoss des Aufrufers, kein Serverfehler.
+            return new JsonResponse(['error' => $e->getMessage()], 400);
         } catch (Exception $e) {
             return new JsonResponse(['error' => $e->getMessage()], 500);
         }

--- a/lib/RoutePackage/MediaUpload.php
+++ b/lib/RoutePackage/MediaUpload.php
@@ -49,6 +49,13 @@ class MediaUpload extends RoutePackage
     /** Nach dieser Zeit gilt ein begonnener Upload als verwaist und wird aufgeraeumt. */
     public const Ttl = 86400; // 24 Stunden
 
+    /**
+     * Alle fuenf Routen teilen sich einen Scope. Einzeln sind sie unbrauchbar --
+     * init ohne chunk, chunk ohne finalize --, und eine Teilvergabe wuerde erst
+     * mitten in der Uebertragung auffallen, wenn die Daten schon geschickt sind.
+     */
+    public const Scope = 'media/upload';
+
     public function loadRoutes(): void
     {
         // Upload beginnen ✅
@@ -88,7 +95,7 @@ class MediaUpload extends RoutePackage
                 ['POST']),
             'Start a chunked upload. Returns an upload_id and the maximum size per chunk.',
             null,
-            new BearerAuth(),
+            new BearerAuth(true, self::Scope),
         );
 
         // Stand des Uploads ✅
@@ -104,7 +111,7 @@ class MediaUpload extends RoutePackage
                 ['GET']),
             'Status of a chunked upload: which chunks arrived, how many bytes are missing.',
             null,
-            new BearerAuth(),
+            new BearerAuth(true, self::Scope),
         );
 
         // Einzelnen Chunk uebertragen ✅
@@ -132,7 +139,7 @@ class MediaUpload extends RoutePackage
                 ['POST', 'PUT']),
             'Send one chunk. Index is zero-based; sending the same index again replaces it.',
             null,
-            new BearerAuth(),
+            new BearerAuth(true, self::Scope),
         );
 
         // Upload abschliessen ✅
@@ -148,7 +155,7 @@ class MediaUpload extends RoutePackage
                 ['POST']),
             'Assemble the chunks and add the file to the media pool.',
             null,
-            new BearerAuth(),
+            new BearerAuth(true, self::Scope),
         );
 
         // Upload abbrechen ✅
@@ -164,7 +171,7 @@ class MediaUpload extends RoutePackage
                 ['DELETE']),
             'Abort a chunked upload and discard the chunks already received.',
             null,
-            new BearerAuth(),
+            new BearerAuth(true, self::Scope),
         );
     }
 

--- a/lib/Token.php
+++ b/lib/Token.php
@@ -127,9 +127,11 @@ class Token
         $Scopes = [];
         foreach (RouteCollection::getRoutes() as $RouteScope => $Route) {
             if ($Route['authorization'] instanceof BearerAuth && $Route['authorization']->requiresScope()) {
-                $Scopes[] = $Route['scope'];
+                // Mehrere Routen koennen sich einen Scope teilen (Chunked Upload):
+                // auf der Token-Seite darf er nur einmal als Checkbox erscheinen.
+                $Scopes[] = $Route['authorization']->getScope((string) $Route['scope']);
             }
         }
-        return $Scopes;
+        return array_values(array_unique($Scopes));
     }
 }

--- a/tests/MediaUploadApiTest.php
+++ b/tests/MediaUploadApiTest.php
@@ -7,11 +7,10 @@ namespace FriendsOfRedaxo\Api\Tests;
 /**
  * Tests für den Chunked Upload (`media/upload/*`).
  *
- * Voraussetzungen am API-Token:
- *   media/upload/init, media/upload/status, media/upload/chunk,
- *   media/upload/finalize, media/upload/delete
+ * Voraussetzung am API-Token: der Scope `media/upload`. Alle fünf Endpunkte
+ * teilen sich diesen einen Scope — einzeln sind sie unbrauchbar.
  *
- * Fehlt einer dieser Scopes, überspringen sich die Tests statt fehlzuschlagen.
+ * Fehlt der Scope, überspringen sich die Tests statt fehlzuschlagen.
  */
 class MediaUploadApiTest extends ApiTestCase
 {
@@ -57,7 +56,7 @@ class MediaUploadApiTest extends ApiTestCase
     {
         $response = $this->post('media/upload', ['filename' => 'evil.php', 'size' => 100]);
         if (401 === $response['status']) {
-            $this->markTestSkipped('Dem Token fehlt der Scope media/upload/init.');
+            $this->markTestSkipped('Dem Token fehlt der Scope media/upload.');
         }
 
         $this->assertStatus(400, $response);
@@ -68,7 +67,7 @@ class MediaUploadApiTest extends ApiTestCase
     {
         $response = $this->post('media/upload', ['filename' => 'a.png', 'size' => 100, 'foo' => 1]);
         if (401 === $response['status']) {
-            $this->markTestSkipped('Dem Token fehlt der Scope media/upload/init.');
+            $this->markTestSkipped('Dem Token fehlt der Scope media/upload.');
         }
 
         $this->assertStatus(400, $response);
@@ -79,7 +78,7 @@ class MediaUploadApiTest extends ApiTestCase
     {
         $zero = $this->post('media/upload', ['filename' => 'a.png', 'size' => 0]);
         if (401 === $zero['status']) {
-            $this->markTestSkipped('Dem Token fehlt der Scope media/upload/init.');
+            $this->markTestSkipped('Dem Token fehlt der Scope media/upload.');
         }
         $this->assertStatus(400, $zero);
 
@@ -174,7 +173,7 @@ class MediaUploadApiTest extends ApiTestCase
     {
         $response = $this->get('media/upload/' . str_repeat('a', 32));
         if (401 === $response['status']) {
-            $this->markTestSkipped('Dem Token fehlt der Scope media/upload/status.');
+            $this->markTestSkipped('Dem Token fehlt der Scope media/upload.');
         }
 
         $this->assertStatus(404, $response);
@@ -199,7 +198,7 @@ class MediaUploadApiTest extends ApiTestCase
         ]);
 
         if (401 === $response['status']) {
-            $this->markTestSkipped('Dem Token fehlen die Scopes media/upload/*.');
+            $this->markTestSkipped('Dem Token fehlt der Scope media/upload.');
         }
 
         $this->assertStatus(201, $response);


### PR DESCRIPTION
Nachtrag zu #72: die fünf Upload-Routen teilen sich jetzt den Scope `media/upload`.

Fünf Scopes waren keine Entscheidung, sondern eine Folge der Technik — der Scope ist in diesem AddOn gleichzeitig der Routenname (`RouteCollection` schlüsselt darüber, `BearerAuth` verglich `$parameters['_route']` direkt). Sachlich ist es falsch: einzeln sind die Endpunkte unbrauchbar, und eine Teilvergabe fällt erst **mitten in der Übertragung** auf, wenn die Daten schon geschickt sind.

`Auth::getScope()` entkoppelt beides: der Routenname bleibt der eindeutige Schlüssel, der geforderte Scope kommt vom Auth-Objekt. `new BearerAuth(true, 'media/upload')` setzt ihn. Das Muster ist für jeden künftigen mehrstufigen Ablauf nutzbar.

Angepasst: die Scope-Prüfung, das `required_scope` in der 401, Filter **und Ausgabe** in `Discovery`, sowie `Token::getAvailableScopes()` mit Dedupe.

Gemessen:

```
Token mit media/upload       → alle fünf Endpunkte, /api/me listet 5, scope: media/upload
Token ohne media/upload      → 0 gelistet (69 statt 74), init → 401 required_scope media/upload
Token mit den fünf ALTEN     → 401 required_scope media/upload  (greifen nicht mehr)
Token-Seite                  → genau eine Checkbox "media/upload"
```

Ein bestehender Test hat dabei eine Regression gefunden, die ich sonst übersehen hätte: `MeApiTest::testOnlyGrantedScopesAreListed` fiel, weil `/api/me` den Routennamen als `scope` ausgab — einen Wert, den kein Token mehr hat. `Discovery` gibt jetzt den effektiven Scope aus.

Nebenbei mitgenommen: `handleAddMedia` beantwortet `rex_api_exception` aus dem Media-Service mit `400` statt `500`. Unerlaubte Endung oder unerlaubter MIME-Typ sind ein Verstoß des Aufrufers, kein Serverfehler — aufgefallen beim Vergleich mit dem neuen `finalize`, das es schon richtig machte.

Kein Migrationspfad nötig: die alten Scopes waren nie in einem Release (`package.yml` steht auf 1.2).

Suite: **215 Tests, 2507 Assertions, 5 Skips**, keine Fehler.

---
*Dieser Text wurde durch eine KI erstellt.*
