### PR TITLE
Standalone-API-Dashboard zurück ins Repository

### DIFF
--- a/assets/dashboard/index.html
+++ b/assets/dashboard/index.html
@@ -1,0 +1,6216 @@
+<!DOCTYPE html>
+<html lang="de" data-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>REDAXO Remote — API Dashboard</title>
+    <style>
+        :root {
+            --bg: #f0f2f5;
+            --bg-card: #ffffff;
+            --bg-card-hover: #f8f9fa;
+            --bg-sidebar: #11151c;
+            --bg-input: #f5f6f8;
+            --text: #1a1d23;
+            --text-muted: #6b7280;
+            --text-sidebar: #94a3b8;
+            --text-sidebar-active: #ffffff;
+            --border: #e5e7eb;
+            --primary: #4b9ad9;
+            --primary-light: #ebf8ff;
+            --primary-dark: #2b6cb0;
+            --success: #10b981;
+            --warning: #f59e0b;
+            --info: #3b82f6;
+            --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+            --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.1);
+            --shadow-lg: 0 10px 25px -5px rgba(0,0,0,0.1);
+            --radius: 12px;
+            --radius-sm: 8px;
+            --transition: 0.2s ease;
+        }
+        [data-theme="dark"] {
+            --bg: #151b23;
+            --bg-card: #1e252f;
+            --bg-card-hover: #252d3a;
+            --bg-sidebar: #11151c;
+            --bg-input: #252d3a;
+            --text: #e2e8f0;
+            --text-muted: #94a3b8;
+            --text-sidebar: #64748b;
+            --border: #2d3642;
+            --primary-light: #162636;
+            --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+            --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.4);
+            --shadow-lg: 0 10px 25px -5px rgba(0,0,0,0.5);
+        }
+        [data-theme="midnight"] {
+            --bg: #0f172a;
+            --bg-card: #1e293b;
+            --bg-card-hover: #334155;
+            --bg-sidebar: #020617;
+            --bg-input: #334155;
+            --text: #f1f5f9;
+            --text-muted: #94a3b8;
+            --text-sidebar: #64748b;
+            --text-sidebar-active: #bae6fd;
+            --border: #1e293b;
+            --primary: #38bdf8;
+            --primary-light: #0c4a6e;
+            --primary-dark: #0284c7;
+            --shadow-sm: 0 1px 2px rgba(0,0,0,0.5);
+        }
+        [data-theme="forest"] {
+            --bg: #1c1c1c;
+            --bg-card: #2a2a2a;
+            --bg-card-hover: #333;
+            --bg-sidebar: #181818;
+            --bg-input: #333;
+            --text: #e0e0e0;
+            --text-muted: #a0a0a0;
+            --text-sidebar: #888;
+            --border: #333;
+            --primary: #10b981;
+            --primary-light: #064e3b;
+            --primary-dark: #047857;
+        }
+        [data-theme="coffee"] {
+            --bg: #fdf6e3;
+            --bg-card: #eee8d5;
+            --bg-card-hover: #e4ddc8;
+            --bg-sidebar: #073642;
+            --bg-input: #fdf6e3;
+            --text: #586e75;
+            --text-muted: #93a1a1;
+            --text-sidebar: #839496;
+            --text-sidebar-active: #fdf6e3;
+            --border: #d3d7cf;
+            --primary: #2aa198;
+            --primary-light: #d6f2ef;
+            --primary-dark: #20756d;
+        }
+        [data-theme="agk"] {
+            --bg: #f5fcf8;
+            --bg-card: #ffffff;
+            --bg-card-hover: #eef7f2;
+            --bg-sidebar: #1e3a23;
+            --bg-input: #f0f9f4;
+            --text: #18281b;
+            --text-muted: #5e7a63;
+            --text-sidebar: #cbdccf;
+            --text-sidebar-active: #ffffff;
+            --border: #dbece0;
+            --primary: #2d8a4e;
+            --primary-light: #e6f4ea;
+            --primary-dark: #1b5e34;
+            --shadow-sm: 0 1px 2px rgba(30, 58, 35, 0.08);
+        }
+        [data-theme="redaxo-backend"] {
+            --bg: #e9edf2;
+            --bg-card: #ffffff;
+            --bg-card-hover: #f3f6fa;
+            --bg-sidebar: #2b3a4e;
+            --bg-input: #f4f7fb;
+            --text: #243142;
+            --text-muted: #6b7b8f;
+            --text-sidebar: #b7c3d2;
+            --text-sidebar-active: #ffffff;
+            --border: #d3dde8;
+            --primary: #3f8ccf;
+            --primary-light: #e5f1fb;
+            --primary-dark: #2f6fa6;
+            --success: #28b97a;
+            --warning: #f39c12;
+            --info: #4f9ee3;
+            --shadow-sm: 0 1px 2px rgba(36, 49, 66, 0.08);
+            --shadow-md: 0 6px 18px -8px rgba(36, 49, 66, 0.22);
+            --shadow-lg: 0 18px 40px -18px rgba(36, 49, 66, 0.3);
+        }
+
+        /* Theme Selector Styles */
+        .theme-selector {
+            position: relative;
+            display: inline-block;
+        }
+        .theme-menu {
+            position: absolute;
+            bottom: 100%;
+            left: 0;
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            padding: 8px;
+            display: none;
+            flex-direction: column;
+            gap: 4px;
+            box-shadow: var(--shadow-lg);
+            min-width: 150px;
+            margin-bottom: 8px;
+        }
+        .theme-menu.active { display: flex; }
+        .theme-option {
+            background: none;
+            border: none;
+            cursor: pointer;
+            padding: 6px 10px;
+            text-align: left; 
+            color: var(--text);
+            border-radius: 4px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 13px;
+        }
+        .theme-option:hover { background: var(--bg-card-hover); }
+        .theme-color-preview {
+            width: 12px; height: 12px;
+            border-radius: 50%;
+            border: 1px solid var(--border);
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            line-height: 1.6;
+            min-height: 100vh;
+        }
+
+        /* ==================== LOGIN ==================== */
+        .login-screen {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            padding: 20px;
+            background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #324050 100%);
+        }
+        .login-card {
+            background: var(--bg-card);
+            border-radius: 20px;
+            padding: 48px;
+            width: 100%;
+            max-width: 460px;
+            box-shadow: var(--shadow-lg);
+        }
+        .login-logo {
+            text-align: center;
+            margin-bottom: 32px;
+        }
+        .login-logo svg { width: 56px; height: 56px; }
+        .login-logo h1 {
+            font-size: 24px;
+            font-weight: 700;
+            margin-top: 12px;
+            color: var(--text);
+        }
+        .login-logo p {
+            color: var(--text-muted);
+            font-size: 14px;
+            margin-top: 4px;
+        }
+        .form-group { margin-bottom: 20px; }
+        .form-group label {
+            display: block;
+            font-size: 13px;
+            font-weight: 600;
+            color: var(--text-muted);
+            margin-bottom: 6px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+        .form-group input,
+        .form-group select,
+        .form-group textarea {
+            width: 100%;
+            padding: 12px 16px;
+            background: var(--bg-input);
+            border: 2px solid var(--border);
+            border-radius: var(--radius-sm);
+            font-size: 15px;
+            color: var(--text);
+            transition: border-color var(--transition);
+            outline: none;
+            font-family: inherit;
+        }
+        .form-group input:focus,
+        .form-group select:focus,
+        .form-group textarea:focus { border-color: var(--primary); }
+        .form-group input::placeholder { color: var(--text-muted); opacity: 0.6; }
+        .form-group select {
+            cursor: pointer;
+            appearance: none;
+            background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+            background-repeat: no-repeat;
+            background-position: right 12px center;
+            background-size: 20px;
+            padding-right: 40px;
+        }
+        .form-select {
+            padding: 8px 12px;
+            background: var(--bg-input);
+            border: 2px solid var(--border);
+            border-radius: var(--radius-sm);
+            font-size: 14px;
+            color: var(--text);
+            cursor: pointer;
+            transition: border-color var(--transition);
+            outline: none;
+            appearance: none;
+            background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+            background-repeat: no-repeat;
+            background-position: right 8px center;
+            background-size: 18px;
+            padding-right: 32px;
+            font-family: inherit;
+        }
+        .form-select:focus { border-color: var(--primary); }
+        
+        /* ==================== ACCORDION ==================== */
+        .accordion-section {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            margin-bottom: 12px;
+            overflow: hidden;
+        }
+        .accordion-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 12px 16px;
+            background: var(--bg-header);
+            border-bottom: 1px solid var(--border);
+            cursor: pointer;
+            user-select: none;
+            transition: background var(--transition);
+        }
+        .accordion-header:hover { background: var(--bg-card-hover); }
+        .accordion-header.collapsed { border-bottom: none; }
+        .accordion-title {
+            font-weight: 600;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            flex: 1;
+        }
+        .accordion-toggle {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 24px;
+            height: 24px;
+            transition: transform 0.3s ease;
+            color: var(--text-muted);
+        }
+        .accordion-header.collapsed .accordion-toggle {
+            transform: rotate(-90deg);
+        }
+        .accordion-content {
+            max-height: 2000px;
+            overflow: hidden;
+            transition: max-height 0.3s ease, padding 0.3s ease;
+            padding: 16px;
+        }
+        .accordion-content.collapsed {
+            max-height: 0;
+            padding: 0 16px;
+        }
+        
+        .btn-primary {
+            width: 100%;
+            padding: 14px;
+            background: var(--primary);
+            color: white;
+            border: none;
+            border-radius: var(--radius-sm);
+            font-size: 15px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background var(--transition), transform var(--transition);
+        }
+        .btn-primary:hover { background: var(--primary-dark); transform: translateY(-1px); }
+        .btn-primary:disabled { opacity: 0.6; cursor: not-allowed; transform: none; }
+        .login-error {
+            background: #fef2f2;
+            color: #dc2626;
+            padding: 12px 16px;
+            border-radius: var(--radius-sm);
+            font-size: 13px;
+            margin-bottom: 16px;
+            display: none;
+            border: 1px solid #fecaca;
+        }
+        .login-hint {
+            margin-top: 20px;
+            padding: 16px;
+            background: var(--bg-input);
+            border-radius: var(--radius-sm);
+            font-size: 12px;
+            color: var(--text-muted);
+            line-height: 1.5;
+        }
+        .login-hint code {
+            background: var(--border);
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 11px;
+        }
+
+        /* ==================== LAYOUT ==================== */
+        .app { display: none; min-height: 100vh; }
+        .app.active { display: flex; }
+
+        /* Sidebar */
+        .sidebar {
+            width: 260px;
+            background: var(--bg-sidebar);
+            color: var(--text-sidebar);
+            display: flex;
+            flex-direction: column;
+            position: fixed;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            z-index: 100;
+            transition: transform 0.3s ease;
+        }
+        .sidebar-header {
+            padding: 24px 20px;
+            border-bottom: 1px solid rgba(255,255,255,0.08);
+        }
+        .sidebar-header h2 {
+            font-size: 18px;
+            font-weight: 700;
+            color: white;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .sidebar-header h2 svg { width: 28px; height: 28px; flex-shrink: 0; }
+        .sidebar-header .instance-url {
+            font-size: 11px;
+            color: var(--text-sidebar);
+            margin-top: 6px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .sidebar-nav { flex: 1; padding: 12px 0; overflow-y: auto; }
+        .nav-section {
+            padding: 8px 20px 4px;
+            font-size: 10px;
+            text-transform: uppercase;
+            letter-spacing: 1.5px;
+            color: rgba(148,163,184,0.5);
+            font-weight: 700;
+        }
+        .nav-item {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 10px 20px;
+            color: var(--text-sidebar);
+            text-decoration: none;
+            font-size: 14px;
+            cursor: pointer;
+            transition: all var(--transition);
+            border-left: 3px solid transparent;
+        }
+        .nav-item:hover { color: white; background: rgba(255,255,255,0.05); }
+        .nav-item.active {
+            color: var(--text-sidebar-active);
+            background: rgba(232,69,60,0.12);
+            border-left-color: var(--primary);
+        }
+        .nav-item svg { width: 18px; height: 18px; flex-shrink: 0; opacity: 0.7; }
+        .nav-item.active svg { opacity: 1; }
+        .nav-item .badge {
+            margin-left: auto;
+            background: rgba(255,255,255,0.1);
+            padding: 2px 8px;
+            border-radius: 10px;
+            font-size: 11px;
+            font-weight: 600;
+        }
+        .nav-item.active .badge { background: var(--primary); color: white; }
+        .sidebar-footer {
+            padding: 16px 20px;
+            border-top: 1px solid rgba(255,255,255,0.08);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+        .sidebar-footer button {
+            background: none;
+            border: none;
+            color: var(--text-sidebar);
+            cursor: pointer;
+            padding: 6px;
+            border-radius: 6px;
+            transition: all var(--transition);
+        }
+        .sidebar-footer button:hover { color: white; background: rgba(255,255,255,0.1); }
+
+        /* Main */
+        .main { flex: 1; margin-left: 260px; min-height: 100vh; }
+        .topbar {
+            height: 64px;
+            background: var(--bg-card);
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 0 32px;
+            position: sticky;
+            top: 0;
+            z-index: 50;
+        }
+        .topbar-left { display: flex; align-items: center; gap: 16px; }
+        .topbar-left h1 { font-size: 20px; font-weight: 700; }
+        .topbar-right { display: flex; align-items: center; gap: 12px; }
+        .topbar-search {
+            position: relative;
+        }
+        .topbar-search input {
+            padding: 8px 12px 8px 36px;
+            background: var(--bg-input);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            font-size: 13px;
+            color: var(--text);
+            width: 240px;
+            outline: none;
+            transition: border-color var(--transition);
+        }
+        .topbar-search input:focus { border-color: var(--primary); }
+        .topbar-search svg {
+            position: absolute;
+            left: 10px;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 16px;
+            height: 16px;
+            color: var(--text-muted);
+        }
+        .theme-toggle {
+            background: var(--bg-input);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            padding: 8px;
+            cursor: pointer;
+            color: var(--text-muted);
+            transition: all var(--transition);
+        }
+        .theme-toggle:hover { color: var(--text); border-color: var(--primary); }
+
+        .content { padding: 32px; }
+        .page { display: none; }
+        .page.active { display: block; }
+
+        /* ==================== DASHBOARD HERO ==================== */
+        .dashboard-hero {
+            background: linear-gradient(135deg, var(--primary) 0%, color-mix(in srgb, var(--primary) 70%, var(--sidebar-bg, #1a2332)) 100%);
+            border-radius: var(--radius);
+            padding: 28px 32px;
+            margin-bottom: 28px;
+            color: #fff;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            box-shadow: var(--shadow-md);
+            overflow: hidden;
+            position: relative;
+        }
+        .dashboard-hero::before {
+            content: '';
+            position: absolute;
+            right: -40px; top: -40px;
+            width: 200px; height: 200px;
+            border-radius: 50%;
+            background: rgba(255,255,255,0.07);
+            pointer-events: none;
+        }
+        .dashboard-hero::after {
+            content: '';
+            position: absolute;
+            right: 60px; bottom: -60px;
+            width: 140px; height: 140px;
+            border-radius: 50%;
+            background: rgba(255,255,255,0.05);
+            pointer-events: none;
+        }
+        .hero-text { flex: 1; }
+        .hero-text h2 {
+            font-size: 22px;
+            font-weight: 700;
+            margin: 0 0 6px;
+            color: #fff;
+        }
+        .hero-text p {
+            margin: 0;
+            font-size: 14px;
+            color: rgba(255,255,255,0.75);
+        }
+        .hero-url {
+            font-size: 12px;
+            color: rgba(255,255,255,0.6);
+            margin-top: 8px;
+            font-family: monospace;
+            word-break: break-all;
+        }
+        .hero-actions {
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+            justify-content: flex-end;
+        }
+        .hero-btn {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 18px;
+            border-radius: 8px;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            border: none;
+            transition: all .15s;
+            white-space: nowrap;
+        }
+        .hero-btn svg { width: 16px; height: 16px; flex-shrink: 0; }
+        .hero-btn.primary {
+            background: rgba(255,255,255,0.2);
+            color: #fff;
+            backdrop-filter: blur(4px);
+        }
+        .hero-btn.primary:hover { background: rgba(255,255,255,0.32); transform: translateY(-1px); }
+        .hero-btn.secondary {
+            background: rgba(255,255,255,0.1);
+            color: rgba(255,255,255,0.9);
+        }
+        .hero-btn.secondary:hover { background: rgba(255,255,255,0.2); }
+
+        /* ==================== STATS CARDS ==================== */
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+            gap: 16px;
+            margin-bottom: 28px;
+        }
+        .stat-card {
+            background: var(--bg-card);
+            border-radius: var(--radius);
+            padding: 20px 20px 18px;
+            box-shadow: var(--shadow-sm);
+            border: 1px solid var(--border);
+            border-top: 3px solid transparent;
+            transition: all var(--transition);
+            cursor: pointer;
+            display: flex;
+            flex-direction: column;
+        }
+        .stat-card:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-md);
+            border-top-color: var(--primary);
+        }
+        .stat-card-top {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            margin-bottom: 12px;
+        }
+        .stat-card .stat-icon {
+            width: 40px;
+            height: 40px;
+            border-radius: 10px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .stat-card .stat-icon svg { width: 20px; height: 20px; }
+        .stat-card .stat-icon.red { background: #fef2f2; color: #e8453c; }
+        .stat-card .stat-icon.blue { background: #eff6ff; color: #3b82f6; }
+        .stat-card .stat-icon.green { background: #f0fdf4; color: #10b981; }
+        .stat-card .stat-icon.amber { background: #fffbeb; color: #f59e0b; }
+        .stat-card .stat-icon.purple { background: #faf5ff; color: #8b5cf6; }
+        .stat-card .stat-icon.teal { background: #f0fdfa; color: #14b8a6; }
+        [data-theme="dark"] .stat-card .stat-icon.red { background: #2d1b1b; }
+        [data-theme="dark"] .stat-card .stat-icon.blue { background: #1b2338; }
+        [data-theme="dark"] .stat-card .stat-icon.green { background: #1b2d1f; }
+        [data-theme="dark"] .stat-card .stat-icon.amber { background: #2d2a1b; }
+        [data-theme="dark"] .stat-card .stat-icon.purple { background: #261b2d; }
+        [data-theme="dark"] .stat-card .stat-icon.teal { background: #1b2d2a; }
+        .stat-card .stat-value {
+            font-size: 30px;
+            font-weight: 800;
+            line-height: 1;
+            margin-bottom: 4px;
+        }
+        .stat-card .stat-label {
+            font-size: 12px;
+            color: var(--text-muted);
+            font-weight: 500;
+            text-transform: uppercase;
+            letter-spacing: .4px;
+        }
+        /* ==================== QUICK ACTIONS ==================== */
+        .quick-actions {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+            gap: 12px;
+            margin-bottom: 28px;
+        }
+        .quick-action-btn {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 14px 16px;
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            cursor: pointer;
+            transition: all .15s;
+            font-size: 13px;
+            font-weight: 600;
+            color: var(--text);
+            text-align: left;
+        }
+        .quick-action-btn:hover {
+            border-color: var(--primary);
+            background: color-mix(in srgb, var(--primary) 6%, var(--bg-card));
+            color: var(--primary);
+        }
+        .quick-action-btn .qa-icon {
+            width: 36px; height: 36px;
+            border-radius: 8px;
+            display: flex; align-items: center; justify-content: center;
+            flex-shrink: 0;
+        }
+        .quick-action-btn .qa-icon svg { width: 18px; height: 18px; }
+        .qa-icon.blue { background: #eff6ff; color: #3b82f6; }
+        .qa-icon.green { background: #f0fdf4; color: #10b981; }
+        .qa-icon.amber { background: #fffbeb; color: #f59e0b; }
+        .qa-icon.purple { background: #faf5ff; color: #8b5cf6; }
+        [data-theme="dark"] .qa-icon.blue { background: #1b2338; }
+        [data-theme="dark"] .qa-icon.green { background: #1b2d1f; }
+        [data-theme="dark"] .qa-icon.amber { background: #2d2a1b; }
+        [data-theme="dark"] .qa-icon.purple { background: #261b2d; }
+        /* ==================== ACTIVITY FEED ==================== */
+        .activity-item {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 10px 0;
+            border-bottom: 1px solid var(--border);
+        }
+        .activity-item:last-child { border-bottom: none; }
+        .activity-thumb {
+            width: 38px; height: 38px;
+            border-radius: 8px;
+            overflow: hidden;
+            flex-shrink: 0;
+            background: var(--bg);
+            display: flex; align-items: center; justify-content: center;
+        }
+        .activity-thumb img { width: 100%; height: 100%; object-fit: cover; }
+        .activity-thumb svg { width: 18px; height: 18px; color: var(--text-muted); }
+        .activity-info { flex: 1; min-width: 0; }
+        .activity-title {
+            font-size: 13px;
+            font-weight: 600;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            color: var(--text);
+        }
+        .activity-meta {
+            font-size: 11px;
+            color: var(--text-muted);
+            margin-top: 2px;
+        }
+        .activity-badge { flex-shrink: 0; }
+
+        /* ==================== DATA TABLE ==================== */
+        .card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-sm);
+            overflow: hidden;
+            margin-bottom: 24px;
+        }
+        .card-header {
+            padding: 20px 24px;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+        .card-header h3 { font-size: 16px; font-weight: 700; }
+        .card-body { padding: 0; }
+        .card-body.padded { padding: 24px; }
+
+        .data-table { width: 100%; border-collapse: collapse; }
+        .data-table th {
+            text-align: left;
+            padding: 12px 16px;
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: var(--text-muted);
+            font-weight: 700;
+            background: var(--bg-input);
+            border-bottom: 1px solid var(--border);
+        }
+        .data-table td {
+            padding: 12px 16px;
+            font-size: 13px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: middle;
+        }
+        .data-table tr:last-child td { border-bottom: none; }
+        .data-table tr:hover td { background: var(--bg-card-hover); }
+        .data-table .id-col { font-weight: 700; color: var(--primary); width: 60px; }
+        .data-table .status-online { color: var(--success); font-weight: 600; }
+        .data-table .status-offline { color: var(--text-muted); }
+        .data-table .date-col { color: var(--text-muted); font-size: 12px; white-space: nowrap; }
+        .data-table .truncate { max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            padding: 3px 10px;
+            border-radius: 20px;
+            font-size: 11px;
+            font-weight: 600;
+        }
+        .pill.online { background: #d1fae5; color: #065f46; }
+        .pill.offline { background: #f3f4f6; color: #6b7280; }
+        .pill.admin { background: #fef3c7; color: #92400e; }
+        [data-theme="dark"] .pill.online { background: #065f46; color: #d1fae5; }
+        [data-theme="dark"] .pill.offline { background: #374151; color: #9ca3af; }
+        [data-theme="dark"] .pill.admin { background: #78350f; color: #fef3c7; }
+
+        /* ==================== TREE ==================== */
+        .tree { padding: 16px; }
+        .tree-node { margin-bottom: 2px; }
+        .tree-node-content {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 12px;
+            border-radius: var(--radius-sm);
+            cursor: pointer;
+            transition: background var(--transition);
+            font-size: 13px;
+        }
+        .tree-node-content:hover { background: var(--bg-card-hover); }
+        .tree-node-content:hover .tree-actions { opacity: 1; }
+        .tree-toggle {
+            width: 18px;
+            height: 18px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: var(--text-muted);
+            transition: transform 0.2s;
+            flex-shrink: 0;
+        }
+        .tree-toggle.open { transform: rotate(90deg); }
+        .tree-toggle.empty { visibility: hidden; }
+        .tree-icon { flex-shrink: 1; width: 18px; height: 18px; }
+        .tree-icon.cat { color: var(--warning); }
+        .tree-icon.art { color: var(--info); }
+        .tree-icon.start { color: var(--primary); }
+        .tree-name { flex: 1; }
+        .tree-meta { font-size: 11px; color: var(--text-muted); }
+        .tree-actions { opacity: 0; transition: opacity 0.2s; margin-left: auto; }
+        .btn-tree-add {
+            background: none; border: none; cursor: pointer; color: var(--text-muted);
+            padding: 2px 6px; border-radius: 4px; font-size: 14px; font-weight: bold;
+        }
+        .btn-tree-add:hover { background: var(--bg-input); color: var(--primary); }
+        .tree-children { margin-left: 26px; display: none; }
+        .tree-children.open { display: block; }
+
+        /* ==================== MEDIA GALLERY ==================== */
+        .media-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+            gap: 16px;
+            padding: 24px;
+        }
+        .media-item {
+            border-radius: var(--radius-sm);
+            border: 1px solid var(--border);
+            overflow: hidden;
+            transition: all var(--transition);
+            cursor: pointer;
+            background: var(--bg-card);
+        }
+        .media-item:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-md);
+            border-color: var(--primary);
+        }
+        .media-thumb {
+            aspect-ratio: 1;
+            background: var(--bg-input);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            overflow: hidden;
+        }
+        .media-thumb img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+        .media-thumb .file-icon {
+            font-size: 32px;
+            color: var(--text-muted);
+        }
+        .media-info {
+            padding: 10px 12px;
+        }
+        .media-info .filename {
+            font-size: 12px;
+            font-weight: 600;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .media-info .filedetails {
+            font-size: 11px;
+            color: var(--text-muted);
+            margin-top: 2px;
+        }
+
+        /* ==================== LOADING ==================== */
+        .spinner {
+            display: inline-block;
+            width: 20px;
+            height: 20px;
+            border: 2px solid var(--border);
+            border-top-color: var(--primary);
+            border-radius: 50%;
+            animation: spin 0.6s linear infinite;
+        }
+        @keyframes spin { to { transform: rotate(360deg); } }
+        .loading-overlay {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+            padding: 60px;
+            color: var(--text-muted);
+            font-size: 14px;
+        }
+        .empty-state {
+            text-align: center;
+            padding: 60px 20px;
+            color: var(--text-muted);
+        }
+        .empty-state svg { width: 48px; height: 48px; margin-bottom: 12px; opacity: 0.3; }
+        .empty-state p { font-size: 14px; }
+
+        /* ==================== MEDIA DETAIL MODAL ==================== */
+        .modal-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(0,0,0,0.6);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+            padding: 24px;
+        }
+        .modal-overlay.active { display: flex; }
+        .modal {
+            background: var(--bg-card);
+            border-radius: var(--radius);
+            max-width: 600px;
+            width: 100%;
+            max-height: 80vh;
+            overflow-y: auto;
+            box-shadow: var(--shadow-lg);
+        }
+        .modal-header {
+            padding: 20px 24px;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .modal-header h3 { font-size: 16px; font-weight: 700; }
+        .modal-close {
+            background: none;
+            border: none;
+            color: var(--text-muted);
+            cursor: pointer;
+            padding: 4px;
+            font-size: 20px;
+        }
+        .modal-body { padding: 24px; }
+        .detail-row {
+            display: flex;
+            padding: 8px 0;
+            border-bottom: 1px solid var(--border);
+            font-size: 13px;
+        }
+        .detail-row:last-child { border-bottom: none; }
+        .detail-label {
+            width: 140px;
+            font-weight: 600;
+            color: var(--text-muted);
+            flex-shrink: 0;
+        }
+        .detail-value { flex: 1; word-break: break-all; }
+
+        /* ==================== RESPONSIVE ==================== */
+        .mobile-menu-btn {
+            display: none;
+            background: none;
+            border: none;
+            color: var(--text);
+            cursor: pointer;
+            padding: 8px;
+        }
+        @media (max-width: 768px) {
+            .sidebar { transform: translateX(-100%); }
+            .sidebar.open { transform: translateX(0); }
+            .main { margin-left: 0; }
+            .mobile-menu-btn { display: block; }
+            .content { padding: 16px; }
+            .stats-grid { grid-template-columns: repeat(2, 1fr); gap: 12px; }
+            .media-grid { grid-template-columns: repeat(2, 1fr); }
+            .topbar-search { display: none; }
+        }
+
+        /* ==================== CODE BLOCK ==================== */
+        .code-block {
+            background: #1e1e2e;
+            color: #cdd6f4;
+            padding: 16px;
+            border-radius: var(--radius-sm);
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: 12px;
+            line-height: 1.6;
+            overflow-x: auto;
+            white-space: pre-wrap;
+            word-break: break-all;
+            max-height: 300px;
+            overflow-y: auto;
+        }
+
+        /* Filters bar */
+        .filter-bar {
+            display: flex;
+            gap: 12px;
+            align-items: center;
+            flex-wrap: wrap;
+        }
+        .filter-bar input {
+            padding: 8px 12px;
+            background: var(--bg-input);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            font-size: 13px;
+            color: var(--text);
+            outline: none;
+            font-family: inherit;
+        }
+        .filter-bar input:focus { border-color: var(--primary); }
+        .filter-bar select {
+            padding: 8px 12px;
+            background: var(--bg-input);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            font-size: 13px;
+            color: var(--text);
+            outline: none;
+            cursor: pointer;
+            appearance: none;
+            background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+            background-repeat: no-repeat;
+            background-position: right 4px center;
+            background-size: 16px;
+            padding-right: 32px;
+            font-family: inherit;
+        }
+        .filter-bar select:focus { border-color: var(--primary); }
+
+        /* Refresh btn */
+        .btn-icon {
+            background: var(--bg-input);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            padding: 7px 10px;
+            cursor: pointer;
+            color: var(--text-muted);
+            transition: all var(--transition);
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 12px;
+        }
+        .btn-icon:hover { border-color: var(--primary); color: var(--primary); }
+        .btn-icon svg { width: 14px; height: 14px; }
+        .btn-danger {
+            border-color: #dc2626;
+            color: #dc2626;
+        }
+        .btn-danger:hover {
+            background: #fef2f2;
+            border-color: #b91c1c;
+            color: #b91c1c;
+        }
+        [data-theme="dark"] .btn-danger:hover {
+            background: #2f1414;
+        }
+
+        /* ==================== API LOG ==================== */
+        .api-log {
+            padding: 16px;
+            max-height: 400px;
+            overflow-y: auto;
+        }
+        .api-log-entry {
+            display: flex;
+            align-items: flex-start;
+            gap: 12px;
+            padding: 8px 12px;
+            border-radius: var(--radius-sm);
+            margin-bottom: 4px;
+            font-size: 12px;
+            font-family: 'SF Mono', monospace;
+        }
+        .api-log-entry:hover { background: var(--bg-card-hover); }
+        .api-log-method {
+            font-weight: 700;
+            width: 40px;
+            flex-shrink: 0;
+        }
+        .api-log-method.GET { color: var(--success); }
+        .api-log-method.POST { color: var(--info); }
+        .api-log-method.DELETE { color: var(--primary); }
+        .api-log-url { color: var(--text); flex: 1; }
+        .api-log-status { font-weight: 600; }
+        .api-log-status.ok { color: var(--success); }
+        .api-log-status.err { color: var(--primary); }
+        .api-log-time { color: var(--text-muted); }
+    </style>
+    <link href="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.snow.css" rel="stylesheet">
+</head>
+<body>
+
+    <!-- ====== LOGIN SCREEN ====== -->
+    <div class="login-screen" id="loginScreen">
+        <div class="login-card">
+            <div class="login-logo">
+                <svg viewBox="0 0 56 56" fill="none"><rect width="56" height="56" rx="14" fill="#4b9ad9"/><path d="M16 20h8v4h-8zm0 6h12v4H16zm0 6h16v4H16zm20-12h4v16h-4z" fill="white" opacity="0.9"/><path d="M28 14l10 6v16l-10 6-10-6V20l10-6z" stroke="white" stroke-width="1.5" fill="none" opacity="0.3"/></svg>
+                <h1>REDAXO Remote</h1>
+                <p>REDAXO API Dashboard</p>
+            </div>
+            <div class="login-error" id="loginError"></div>
+            <form id="loginForm" novalidate>
+                <div class="form-group">
+                    <label>REDAXO URL</label>
+                    <input type="text" id="inputUrl" placeholder="https://localhost:8443" autocomplete="off">
+                </div>
+                <div class="form-group">
+                    <label>API Token</label>
+                    <input type="text" id="inputToken" placeholder="Dein API-Token" autocomplete="off">                </div>
+                <button type="submit" class="btn-primary" id="btnConnect">
+                    Verbinden
+                </button>
+            </form>
+            <div class="login-hint">
+                <strong>Hinweis:</strong> Erstelle einen API-Token im REDAXO-Backend unter
+                <code>API → Token</code>. Stelle sicher, dass alle benötigten Scopes aktiviert sind.
+            </div>
+        </div>
+    </div>
+
+    <!-- ====== APP ====== -->
+    <div class="app" id="app">
+        <!-- Sidebar -->
+        <aside class="sidebar" id="sidebar">
+            <div class="sidebar-header">
+                <h2>
+                    <svg viewBox="0 0 28 28" fill="none"><rect width="28" height="28" rx="7" fill="#4b9ad9"/><path d="M8 10h4v2H8zm0 3h6v2H8zm0 3h8v2H8zm10-6h2v8h-2z" fill="white" opacity="0.9"/></svg>
+                    REDAXO Remote
+                </h2>
+                <div class="instance-url" id="instanceUrl"></div>
+            </div>
+            <nav class="sidebar-nav">
+                <div class="nav-section">Übersicht</div>
+                <div class="nav-item active" data-page="dashboard" onclick="navigateTo('dashboard')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+                    Dashboard
+                </div>
+                <div class="nav-section">Inhalte</div>
+                <div class="nav-item" data-page="structure" onclick="navigateTo('structure')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+                    Struktur
+                    <span class="badge" id="badgeArticles">–</span>
+                </div>
+                <div class="nav-item" data-page="media" onclick="navigateTo('media')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+                    Medien
+                    <span class="badge" id="badgeMedia">–</span>
+                </div>
+                <div class="nav-section">System</div>
+                <div class="nav-item" data-page="templates" onclick="navigateTo('templates')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                    Templates
+                    <span class="badge" id="badgeTemplates">–</span>
+                </div>
+                <div class="nav-item" data-page="modules" onclick="navigateTo('modules')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+                    Module
+                    <span class="badge" id="badgeModules">–</span>
+                </div>
+                <div class="nav-item" data-page="pagebuilder" onclick="navigateTo('pagebuilder')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M8 7h8"/><path d="M8 12h8"/><path d="M8 17h5"/></svg>
+                    Pagebuilder
+                </div>
+                <div class="nav-item" data-page="users" onclick="navigateTo('users')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
+                    Benutzer
+                    <span class="badge" id="badgeUsers">–</span>
+                </div>
+                <div class="nav-item" data-page="clangs" onclick="navigateTo('clangs')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>
+                    Sprachen
+                    <span class="badge" id="badgeClangs">–</span>
+                </div>
+                <div class="nav-item" data-page="metainfo" onclick="navigateTo('metainfo')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16v16H4z"/><path d="M8 8h8"/><path d="M8 12h8"/><path d="M8 16h5"/></svg>
+                    Metafelder
+                </div>
+                <div class="nav-section">Support & Wartung</div>
+                <div class="nav-item" data-page="system" onclick="navigateTo('system')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="2" y1="20" x2="22" y2="20"/></svg>
+                    System
+                </div>
+                <div class="nav-item" data-page="addons" onclick="navigateTo('addons')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 13.39a2 2 0 002 1.61h9.72a2 2 0 002-1.61L23 6H6"/></svg>
+                    Addons
+                </div>
+                <div class="nav-item" data-page="cache" onclick="navigateTo('cache')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16v16H4z"/><circle cx="12" cy="12" r="3"/><line x1="8" y1="8" x2="8" y2="8"/><line x1="16" y1="8" x2="16" y2="8"/><line x1="8" y1="16" x2="8" y2="16"/><line x1="16" y1="16" x2="16" y2="16"/></svg>
+                    Cache
+                </div>
+                <div class="nav-item" data-page="errorlog" onclick="navigateTo('errorlog')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-2h2v2m0-4h-2V7h2v6z"/></svg>
+                    Fehlerlog
+                </div>
+                <div class="nav-section">Debug</div>
+                <div class="nav-item" data-page="apilog" onclick="navigateTo('apilog')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
+                    API Log
+                    <span class="badge" id="badgeLog">0</span>
+                </div>
+                <div class="nav-item" data-page="apireport" onclick="navigateTo('apireport')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/><circle cx="9" cy="10" r="1"/><path d="M12 10h.01"/><circle cx="15" cy="10" r="1"/></svg>
+                    API Report
+                </div>
+            </nav>
+            <div class="sidebar-footer">
+                <div class="theme-selector">
+                    <button id="themeBtn" title="Theme ändern" onclick="toggleThemeMenu()" style="background:none; border:none; color:var(--text-sidebar); cursor:pointer;">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+                    </button>
+                    <div class="theme-menu" id="themeMenu">
+                        <button class="theme-option" onclick="setTheme('light')"><span class="theme-color-preview" style="background:#f0f2f5;"></span> Light</button>
+                        <button class="theme-option" onclick="setTheme('dark')"><span class="theme-color-preview" style="background:#151b23;"></span> Dark</button>
+                        <button class="theme-option" onclick="setTheme('midnight')"><span class="theme-color-preview" style="background:#0f172a;"></span> Midnight</button>
+                        <button class="theme-option" onclick="setTheme('forest')"><span class="theme-color-preview" style="background:#1c1c1c;"></span> Forest</button>
+                        <button class="theme-option" onclick="setTheme('coffee')"><span class="theme-color-preview" style="background:#fdf6e3;"></span> Coffee</button>
+                        <button class="theme-option" onclick="setTheme('agk')"><span class="theme-color-preview" style="background:#f0f7f4; border:1px solid #4caf50;"></span> AGK</button>
+                        <button class="theme-option" onclick="setTheme('redaxo-backend')"><span class="theme-color-preview" style="background:#3f8ccf; border:1px solid #2b3a4e;"></span> REDAXO Backend</button>
+                    </div>
+                </div>
+                <div style="flex:1"></div>
+                <button onclick="disconnect()" title="Abmelden" style="background:none; border:none; color:var(--text-sidebar); cursor:pointer;">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+                </button>
+            </div>
+        </aside>
+
+        <!-- Main Content -->
+        <div class="main">
+            <div class="topbar">
+                <div class="topbar-left">
+                    <button class="mobile-menu-btn" onclick="toggleSidebar()">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="24" height="24"><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+                    </button>
+                    <h1 id="pageTitle">Dashboard</h1>
+                </div>
+                <div class="topbar-right">
+                    <div class="topbar-search">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+                        <input type="text" placeholder="Artikel suchen…" id="globalSearch" oninput="handleGlobalSearch(this.value)">
+                    </div>
+                    <button class="theme-toggle" onclick="toggleTheme()" title="Theme wechseln">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+                    </button>
+                </div>
+            </div>
+
+            <div class="content">
+                <!-- ====== DASHBOARD PAGE ====== -->
+                <div class="page active" id="page-dashboard">
+
+                    <!-- Hero Banner -->
+                    <div class="dashboard-hero" id="dashboardHero">
+                        <div class="hero-text">
+                            <h2>Willkommen im Control Panel</h2>
+                            <p id="heroDashSubtitle">REDAXO API Dashboard — alle Inhalte auf einen Blick</p>
+                            <div class="hero-url" id="heroUrl"></div>
+                        </div>
+                        <div class="hero-actions">
+                            <button class="hero-btn primary" onclick="showCreateModal(0)">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+                                Artikel erstellen
+                            </button>
+                            <button class="hero-btn secondary" onclick="navigateTo('media')">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                                Medien
+                            </button>
+                            <button class="hero-btn secondary" onclick="navigateTo('pagebuilder')">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+                                Pagebuilder
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Stats -->
+                    <div class="stats-grid" id="statsGrid">
+                        <div class="stat-card" onclick="navigateTo('structure')">
+                            <div class="stat-card-top">
+                                <div>
+                                    <div class="stat-value" id="statArticles"><span class="spinner"></span></div>
+                                    <div class="stat-label">Artikel</div>
+                                </div>
+                                <div class="stat-icon red"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg></div>
+                            </div>
+                        </div>
+                        <div class="stat-card" onclick="navigateTo('media')">
+                            <div class="stat-card-top">
+                                <div>
+                                    <div class="stat-value" id="statMedia"><span class="spinner"></span></div>
+                                    <div class="stat-label">Medien</div>
+                                </div>
+                                <div class="stat-icon blue"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg></div>
+                            </div>
+                        </div>
+                        <div class="stat-card" onclick="navigateTo('templates')">
+                            <div class="stat-card-top">
+                                <div>
+                                    <div class="stat-value" id="statTemplates"><span class="spinner"></span></div>
+                                    <div class="stat-label">Templates</div>
+                                </div>
+                                <div class="stat-icon green"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg></div>
+                            </div>
+                        </div>
+                        <div class="stat-card" onclick="navigateTo('modules')">
+                            <div class="stat-card-top">
+                                <div>
+                                    <div class="stat-value" id="statModules"><span class="spinner"></span></div>
+                                    <div class="stat-label">Module</div>
+                                </div>
+                                <div class="stat-icon amber"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></div>
+                            </div>
+                        </div>
+                        <div class="stat-card" onclick="navigateTo('users')">
+                            <div class="stat-card-top">
+                                <div>
+                                    <div class="stat-value" id="statUsers"><span class="spinner"></span></div>
+                                    <div class="stat-label">Benutzer</div>
+                                </div>
+                                <div class="stat-icon purple"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/></svg></div>
+                            </div>
+                        </div>
+                        <div class="stat-card" onclick="navigateTo('clangs')">
+                            <div class="stat-card-top">
+                                <div>
+                                    <div class="stat-value" id="statClangs"><span class="spinner"></span></div>
+                                    <div class="stat-label">Sprachen</div>
+                                </div>
+                                <div class="stat-icon teal"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg></div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Quick Actions -->
+                    <div class="quick-actions">
+                        <button class="quick-action-btn" onclick="showCreateModal(0)">
+                            <div class="qa-icon blue"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg></div>
+                            Artikel erstellen
+                        </button>
+                        <button class="quick-action-btn" onclick="navigateTo('media');setTimeout(showMediaUploadForm,200)">
+                            <div class="qa-icon green"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg></div>
+                            Datei hochladen
+                        </button>
+                        <button class="quick-action-btn" onclick="navigateTo('structure')">
+                            <div class="qa-icon amber"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 9 12 2 21 9"/><path d="M3 9v11a1 1 0 001 1h5v-6h6v6h5a1 1 0 001-1V9"/></svg></div>
+                            Struktur verwalten
+                        </button>
+                        <button class="quick-action-btn" onclick="navigateTo('pagebuilder')">
+                            <div class="qa-icon purple"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg></div>
+                            Pagebuilder
+                        </button>
+                    </div>
+
+                    <!-- Recent Activity -->
+                    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 24px;">
+                        <div class="card">
+                            <div class="card-header">
+                                <h3>Zuletzt aktualisierte Artikel</h3>
+                                <button class="btn btn-sm btn-secondary" onclick="navigateTo('structure')" style="font-size:12px;padding:4px 10px;">Alle →</button>
+                            </div>
+                            <div class="card-body" id="recentArticles">
+                                <div class="loading-overlay"><span class="spinner"></span> Lade…</div>
+                            </div>
+                        </div>
+                        <div class="card">
+                            <div class="card-header">
+                                <h3>Zuletzt hinzugefügte Medien</h3>
+                                <button class="btn btn-sm btn-secondary" onclick="navigateTo('media')" style="font-size:12px;padding:4px 10px;">Alle →</button>
+                            </div>
+                            <div class="card-body" id="recentMedia">
+                                <div class="loading-overlay"><span class="spinner"></span> Lade…</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ====== STRUCTURE PAGE ====== -->
+                <div class="page" id="page-structure">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>Seitenstruktur</h3>
+                            <div class="filter-bar">
+                                <select id="structureClangFilter" onchange="changeStructureClang(this.value)" class="form-select">
+                                    <option value="">-- Sprache wählen --</option>
+                                </select>
+                                <button class="btn-icon" onclick="showCreateModal(0)">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                                    Neu
+                                </button>
+                                <button class="btn-icon" onclick="loadStructure()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+                                    Aktualisieren
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card-body" id="structureTree">
+                            <div class="loading-overlay"><span class="spinner"></span> Lade Struktur…</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ====== MEDIA PAGE ====== -->
+                <div class="page" id="page-media">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>Medienpool</h3>
+                            <div class="filter-bar">
+                                <select id="mediaCategoryFilter" onchange="filterMedia()" class="form-select">
+                                    <option value="">Alle Kategorien</option>
+                                </select>
+                                <select id="mediaTypeFilter" onchange="filterMedia()" class="form-select">
+                                    <option value="">Alle Typen</option>
+                                    <option value="image">Bilder</option>
+                                    <option value="application/pdf">PDF</option>
+                                    <option value="video">Videos</option>
+                                    <option value="audio">Audio</option>
+                                </select>
+                                <select id="mediaSortFilter" onchange="filterMedia()" class="form-select">
+                                    <option value="newest">Neueste zuerst</option>
+                                    <option value="oldest">Aelteste zuerst</option>
+                                    <option value="az">A-Z (Dateiname)</option>
+                                    <option value="za">Z-A (Dateiname)</option>
+                                </select>
+                                <input type="text" placeholder="Dateiname filtern…" id="mediaSearchInput" oninput="filterMedia()">
+                                <button class="btn-icon" onclick="showMediaUploadForm()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                                    Hochladen
+                                </button>
+                                <button class="btn-icon" onclick="showMediaCategoryManager()">
+                                    Kategorien
+                                </button>
+                                <button class="btn-icon" onclick="loadMedia()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card-body" id="mediaGallery">
+                            <div class="loading-overlay"><span class="spinner"></span> Lade Medien…</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ====== TEMPLATES PAGE ====== -->
+                <div class="page" id="page-templates">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>Templates</h3>
+                            <div class="filter-bar">
+                                <button class="btn-icon" onclick="showTemplateEditor()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                                    Neu
+                                </button>
+                                <button class="btn-icon" onclick="loadTemplates()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+                                    Aktualisieren
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card-body" id="templatesTable">
+                            <div class="loading-overlay"><span class="spinner"></span> Lade Templates…</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ====== MODULES PAGE ====== -->
+                <div class="page" id="page-modules">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>Module</h3>
+                            <div class="filter-bar">
+                                <button class="btn-icon" onclick="showModuleEditor()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                                    Neu
+                                </button>
+                                <button class="btn-icon" onclick="loadModules()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+                                    Aktualisieren
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card-body" id="modulesTable">
+                            <div class="loading-overlay"><span class="spinner"></span> Lade Module…</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ====== PAGEBUILDER PAGE ====== -->
+                <div class="page" id="page-pagebuilder">
+                    <div id="pagebuilderContent"></div>
+                </div>
+
+                <!-- ====== USERS PAGE ====== -->
+                <div class="page" id="page-users">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>Benutzer</h3>
+                            <div class="filter-bar">
+                                <button class="btn-icon" onclick="showUserEditor()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                                    Neu
+                                </button>
+                                <button class="btn-icon" onclick="loadUsers()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+                                    Aktualisieren
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card-body" id="usersTable">
+                            <div class="loading-overlay"><span class="spinner"></span> Lade Benutzer…</div>
+                        </div>
+                    </div>
+                    <div class="card" style="margin-top: 24px;">
+                        <div class="card-header">
+                            <h3>Rollen</h3>
+                            <div class="filter-bar">
+                                <button class="btn-icon" onclick="showRoleEditor()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                                    Neu
+                                </button>
+                                <button class="btn-icon" onclick="loadUsers()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+                                    Aktualisieren
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card-body" id="rolesTable">
+                            <div class="loading-overlay"><span class="spinner"></span> Lade Rollen…</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ====== CLANGS PAGE ====== -->
+                <div class="page" id="page-clangs">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>Sprachen</h3>
+                            <div class="filter-bar">
+                                <button class="btn-icon" onclick="showClangEditor()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                                    Neu
+                                </button>
+                                <button class="btn-icon" onclick="loadClangs()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+                                    Aktualisieren
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card-body" id="clangsTable">
+                            <div class="loading-overlay"><span class="spinner"></span> Lade Sprachen…</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ====== SYSTEM PAGE ====== -->
+                <div class="page" id="page-system">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>System-Dashboard</h3>
+                        </div>
+                        <div class="card-body" id="systemDashboard">
+                            <div class="loading-overlay"><span class="spinner"></span> Laden…</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ====== ADDONS PAGE ====== -->
+                <div class="page" id="page-addons">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>Addon-Verwaltung</h3>
+                            <div class="filter-bar">
+                                <button class="btn-icon" onclick="loadAddons()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+                                    Aktualisieren
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card-body" id="addonsTable">
+                            <div class="loading-overlay"><span class="spinner"></span> Lade Addons…</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ====== CACHE PAGE ====== -->
+                <div class="page" id="page-cache">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>Cache-Verwaltung</h3>
+                            <div class="filter-bar">
+                                <button class="btn-icon btn-primary" style="width:auto;" onclick="clearAllCache()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22"/><path d="M6 7V5a2 2 0 012-2h8a2 2 0 012 2v2"/></svg>
+                                    Alle löschen
+                                </button>
+                                <button class="btn-icon" onclick="loadCacheStatus()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+                                    Aktualisieren
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card-body" id="cacheStatus">
+                            <div class="loading-overlay"><span class="spinner"></span> Laden…</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ====== ERROR LOG PAGE ====== -->
+                <div class="page" id="page-errorlog">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>Fehlerlog</h3>
+                            <div class="filter-bar">
+                                <input type="text" placeholder="Nach Fehler suchen…" id="errorSearchInput" style="padding:8px 12px; border:1px solid var(--border); border-radius:var(--radius-sm); background:var(--bg-input); color:var(--text);" oninput="filterErrorLog()">
+                                <button class="btn-icon btn-danger" onclick="clearErrorLog()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22"/><path d="M6 7V5a2 2 0 012-2h8a2 2 0 012 2v2"/></svg>
+                                    Löschen
+                                </button>
+                                <button class="btn-icon" onclick="loadErrorLog()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+                                    Aktualisieren
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card-body" id="errorLogTable">
+                            <div class="loading-overlay"><span class="spinner"></span> Lade Fehlerlog…</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ====== METAINFO PAGE ====== -->
+                <div class="page" id="page-metainfo">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>Metafelder</h3>
+                            <div class="filter-bar">
+                                <select id="metainfoPrefixFilter" onchange="renderMetainfoFields()">
+                                    <option value="">Alle Prefixe</option>
+                                    <option value="art_">Artikel (art_)</option>
+                                    <option value="cat_">Kategorien (cat_)</option>
+                                    <option value="med_">Medien (med_)</option>
+                                    <option value="clang_">Sprachen (clang_)</option>
+                                </select>
+                                <button class="btn-icon" onclick="showMetainfoFieldEditor()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                                    Neu
+                                </button>
+                                <button class="btn-icon" onclick="loadMetainfo()">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+                                    Aktualisieren
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card-body" id="metainfoTable">
+                            <div class="loading-overlay"><span class="spinner"></span> Lade Metafelder…</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ====== API LOG PAGE ====== -->
+                <div class="page" id="page-apilog">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>API Request Log</h3>
+                            <button class="btn-icon" onclick="clearApiLog()">Leeren</button>
+                        </div>
+                        <div class="card-body">
+                            <div class="api-log" id="apiLogList">
+                                <div class="empty-state">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
+                                    <p>Noch keine API-Requests aufgezeichnet.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ====== API REPORT ====== -->
+                <div class="page" id="page-apireport">
+                    <div id="apiReportContent"></div>
+                </div>
+
+                <!-- ====== SEARCH RESULTS ====== -->
+                <div class="page" id="page-search">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>Suchergebnisse</h3>
+                        </div>
+                        <div class="card-body" id="searchResults">
+                            <div class="empty-state"><p>Suchbegriff eingeben…</p></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Detail Modal -->
+    <div class="modal-overlay" id="detailModal" onclick="if(event.target===this)closeModal()">
+        <div class="modal">
+            <div class="modal-header">
+                <h3 id="modalTitle">Details</h3>
+                <button class="modal-close" onclick="closeModal()">&times;</button>
+            </div>
+            <div class="modal-body" id="modalBody"></div>
+        </div>
+    </div>
+
+<script>
+// ============================================================
+// REDAXO Remote — Standalone API Dashboard
+// Nutzt die REDAXO API AddOn Endpoints
+// ============================================================
+
+const CONFIG = {
+    url: '',
+    token: '',
+};
+
+const STATE = {
+    articles: [],
+    media: [],
+    templates: [],
+    modules: [],
+    users: [],
+    roles: [],
+    clangs: [],
+    metainfoTypes: [],
+    metainfoFields: [],
+    apiLog: [],
+    mediaCategories: [],
+    pagebuilderStatusCache: {},
+    pagebuilderModuleId: null,
+    currentClang: 1,
+    currentTheme: localStorage.getItem('rex_api_theme') || 'light',
+};
+
+function unwrapListPayload(payload) {
+    if (Array.isArray(payload)) return payload;
+    if (payload && Array.isArray(payload.data)) return payload.data;
+    return [];
+}
+
+// ==================== THEME MANAGER ====================
+function setTheme(themeName) {
+    document.documentElement.setAttribute('data-theme', themeName);
+    STATE.currentTheme = themeName;
+    localStorage.setItem('rex_api_theme', themeName);
+    
+    // Close menu if open
+    document.getElementById('themeMenu').classList.remove('active');
+}
+
+function toggleThemeMenu() {
+    document.getElementById('themeMenu').classList.toggle('active');
+}
+
+// Close theme menu when clicking outside
+document.addEventListener('click', (e) => {
+    const menu = document.getElementById('themeMenu');
+    const btn = document.getElementById('themeBtn');
+    if (menu.classList.contains('active') && !menu.contains(e.target) && !btn.contains(e.target)) {
+        menu.classList.remove('active');
+    }
+});
+
+// Init theme
+setTheme(STATE.currentTheme);
+
+
+// ==================== API CLIENT ====================
+
+async function apiRequest(method, path, body = null) {
+    const url = `${CONFIG.url}/api/${path}`;
+    const start = performance.now();
+
+    const headers = {
+        'Authorization': `Bearer ${CONFIG.token}`,
+        'Accept': 'application/json',
+    };
+
+    const opts = { method, headers };
+
+    if (body) {
+        if (body instanceof FormData) {
+            opts.body = body;
+        } else {
+            headers['Content-Type'] = 'application/json';
+            opts.body = JSON.stringify(body);
+        }
+    }
+    
+    console.log(`📡 API Request: ${method} ${url}`, opts);
+    
+    // Debug headers specifically to catch SyntaxError in Headers
+    try {
+        new Headers(headers);
+    } catch (e) {
+        console.error('❌ Header Validation Error:', e);
+        throw new Error(`Ungültige Header-Zeichen (z.B. im Token): ${e.message}`);
+    }
+
+    try {
+        const res = await fetch(url, opts);
+        const elapsed = Math.round(performance.now() - start);
+        let data = null;
+
+        const ct = res.headers.get('content-type') || '';
+        if (ct.includes('json')) {
+            data = await res.json();
+        } else {
+            data = await res.text();
+        }
+
+        logApiRequest(method, path, res.status, elapsed);
+
+        if (!res.ok) {
+            const errMsg = (data && data.error) ? data.error : `HTTP ${res.status}`;
+            console.error(`❌ API Error ${res.status}:`, errMsg);
+            throw new Error(errMsg);
+        }
+
+        console.log(`✅ API Success:`, data);
+        return data;
+    } catch (err) {
+        console.error('🔥 Fetch error:', err);
+        const elapsed = Math.round(performance.now() - start);
+        if (!err.message.startsWith('HTTP ')) {
+            logApiRequest(method, path, 0, elapsed);
+        }
+        // Improve error messages for common network issues
+        if (err instanceof TypeError || err.name === 'TypeError') {
+            const msg = err.message || '';
+            if (msg.includes('match the expected pattern') || msg.includes('Failed to fetch') || msg.includes('Load failed') || msg.includes('NetworkError') || msg.includes('Network request failed')) {
+                // Likely SSL self-signed cert or CORS issue
+                // Check simple cases first before complex string logic that might fail
+                if (CONFIG.url.startsWith('https:') && location.protocol === 'http:') {
+                     throw new Error('Mixed-Content blockiert: Dashboard läuft auf HTTP, API auf HTTPS. Öffne das Dashboard über die REDAXO-URL: ' + CONFIG.url + '/assets/addons/api/dashboard/index.html');
+                }
+                
+                // Safe check for Cross Origin
+                let isCrossOrigin = false;
+                try {
+                    if (CONFIG.url && location.protocol.startsWith('http')) {
+                        const targetOrigin = new URL(CONFIG.url).origin;
+                        isCrossOrigin = location.origin !== targetOrigin;
+                    }
+                } catch (e) { /* ignore url parsing errors */ }
+                
+                 if (CONFIG.url.includes('localhost') || CONFIG.url.includes('127.0.0.1')) {
+                    throw new Error('Netzwerkfehler – vermutlich selbstsigniertes SSL-Zertifikat. Öffne zuerst ' + CONFIG.url + ' im Browser und akzeptiere das Zertifikat. Oder öffne das Dashboard direkt über: ' + CONFIG.url + '/assets/addons/api/dashboard/index.html');
+                } else if (isCrossOrigin) {
+                     throw new Error('CORS-Fehler – Zugriff blockiert. Das Dashboard muss auf derselben Domain laufen oder CORS-Header senden.');
+                } else {
+                    throw new Error('Netzwerkfehler – Server nicht erreichbar. Prüfe die URL.');
+                }
+            }
+        }
+        throw err;
+    }
+}
+
+function logApiRequest(method, path, status, elapsed) {
+    STATE.apiLog.unshift({ method, path, status, elapsed, time: new Date() });
+    const badge = document.getElementById('badgeLog');
+    if (badge) badge.textContent = STATE.apiLog.length;
+}
+
+// ==================== AUTH / CONNECTION ====================
+
+document.getElementById('loginForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const btn = document.getElementById('btnConnect');
+    const errEl = document.getElementById('loginError');
+    errEl.style.display = 'none';
+    btn.disabled = true;
+    btn.textContent = 'Verbinde…';
+
+    let url = document.getElementById('inputUrl').value.trim().replace(/\/+$/, '');
+    if (url && !/^https?:\/\//i.test(url)) {
+        url = 'https://' + url;
+    }
+    // Validation of URL syntax immediately
+    try {
+        new URL(url);
+    } catch (e) {
+        errEl.textContent = 'Ungültiges URL-Format.';
+        errEl.style.display = 'block';
+        btn.disabled = false;
+        btn.textContent = 'Verbinden';
+        return;
+    }
+
+    document.getElementById('inputUrl').value = url;
+    // Sanitize token (remove potential invisible chars or newlines that cause SyntaxError in headers)
+    CONFIG.token = document.getElementById('inputToken').value.trim().replace(/[\r\n\t]/g, '');
+
+    if (!url || !CONFIG.token) {
+        errEl.textContent = 'Bitte URL und Token eingeben.';
+        errEl.style.display = 'block';
+        btn.disabled = false;
+        btn.textContent = 'Verbinden';
+        return;
+    }
+
+    console.log('🔌 Connecting to:', url);
+    CONFIG.url = url;
+
+    try {
+        // Test connection with clangs endpoint (lightweight)
+        await apiRequest('GET', 'system/clangs');
+
+        // Save to sessionStorage
+        sessionStorage.setItem('cp_url', CONFIG.url);
+        sessionStorage.setItem('cp_token', CONFIG.token);
+
+        showApp();
+    } catch (err) {
+        errEl.textContent = `Verbindung fehlgeschlagen: ${err.message}. Prüfe URL und Token.`;
+        errEl.style.display = 'block';
+    } finally {
+        btn.disabled = false;
+        btn.textContent = 'Verbinden';
+    }
+});
+
+function showApp() {
+    document.getElementById('loginScreen').style.display = 'none';
+    document.getElementById('app').classList.add('active');
+    document.getElementById('instanceUrl').textContent = CONFIG.url;
+    loadDashboard();
+
+    const savedPage = sessionStorage.getItem('cp_page') || 'dashboard';
+    navigateTo(savedPage);
+}
+
+function disconnect() {
+    sessionStorage.removeItem('cp_url');
+    sessionStorage.removeItem('cp_token');
+    sessionStorage.removeItem('cp_page');
+    CONFIG.url = '';
+    CONFIG.token = '';
+    document.getElementById('app').classList.remove('active');
+    document.getElementById('loginScreen').style.display = 'flex';
+}
+
+// Auto-reconnect from session
+(function autoConnect() {
+    const url = sessionStorage.getItem('cp_url');
+    const token = sessionStorage.getItem('cp_token');
+    if (url && token) {
+        CONFIG.url = url;
+        CONFIG.token = token;
+        document.getElementById('inputUrl').value = url;
+        document.getElementById('inputToken').value = token;
+        showApp();
+    }
+})();
+
+// ==================== NAVIGATION ====================
+
+function navigateTo(page) {
+    const validPages = ['dashboard', 'structure', 'media', 'templates', 'modules', 'pagebuilder', 'users', 'clangs', 'metainfo', 'system', 'addons', 'cache', 'errorlog', 'apilog', 'apireport', 'search'];
+    if (!validPages.includes(page)) {
+        page = 'dashboard';
+    }
+
+    document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
+    document.querySelectorAll('.nav-item').forEach(n => n.classList.remove('active'));
+    const el = document.getElementById(`page-${page}`);
+    if (el) el.classList.add('active');
+    const nav = document.querySelector(`.nav-item[data-page="${page}"]`);
+    if (nav) nav.classList.add('active');
+
+    sessionStorage.setItem('cp_page', page);
+
+    const titles = {
+        dashboard: 'Dashboard', structure: 'Seitenstruktur', media: 'Medienpool',
+        templates: 'Templates', modules: 'Module', pagebuilder: 'Minimaler Pagebuilder', users: 'Benutzer',
+        clangs: 'Sprachen', metainfo: 'Metafelder', apilog: 'API Log', search: 'Suche',
+        system: 'System-Dashboard', addons: 'Addon-Verwaltung', cache: 'Cache-Verwaltung', errorlog: 'Fehlerlog',
+        apireport: 'API Featurebericht'
+    };
+    document.getElementById('pageTitle').textContent = titles[page] || page;
+
+    // Lazy load
+    const loaders = {
+        structure: loadStructure,
+        media: loadMedia,
+        templates: loadTemplates,
+        modules: loadModules,
+        pagebuilder: loadPagebuilder,
+        users: loadUsers,
+        clangs: loadClangs,
+        metainfo: loadMetainfo,
+        apilog: renderApiLog,
+        system: loadSystemDashboard,
+        addons: loadAddons,
+        cache: loadCacheStatus,
+        errorlog: loadErrorLog,
+        apireport: loadApiReport,
+    };
+    if (loaders[page]) loaders[page]();
+
+    // Close mobile sidebar
+    document.getElementById('sidebar').classList.remove('open');
+}
+
+function toggleSidebar() {
+    document.getElementById('sidebar').classList.toggle('open');
+}
+
+// ==================== PAGEBUILDER ====================
+
+const PAGEBUILDER_TEMPLATE_KEY = 'pagebuilder_minimal_template';
+const PAGEBUILDER_MODULE_KEY = 'pagebuilder_minimal_module';
+// Versionsnummer erhoehen wenn sich das Modul-Output aendert -> erzwingt Auto-Update
+const PAGEBUILDER_MODULE_VERSION = 6;
+
+function getPagebuilderDemoPayload() {
+    return {
+        blocks: [
+            { type: 'heading', level: 1, text: 'Hallo Welt' },
+            { type: 'text', text: 'Das ist ein minimaler Pagebuilder-Block.' },
+            { type: 'image', src: 'example.jpg', alt: 'Beispielbild' },
+        ],
+    };
+}
+
+function buildMinimalPagebuilderTemplateContent() {
+    return `<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= rex_escape(rex_article::getCurrent()->getName()) ?></title>
+    <style>
+        body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, sans-serif; background: #f7f7f8; color: #111827; }
+        .pb-shell { max-width: 960px; margin: 0 auto; padding: 32px 16px; }
+        .pb-shell h1 { margin: 0 0 8px; font-size: 28px; }
+        .pb-shell .meta { color: #6b7280; margin-bottom: 24px; font-size: 14px; }
+        .pb-content { background: #fff; border: 1px solid #e5e7eb; border-radius: 10px; padding: 20px; }
+    </style>
+</head>
+<body>
+    <main class="pb-shell">
+        <h1><?= rex_escape(rex_article::getCurrent()->getName()) ?></h1>
+        <p class="meta">Rendering ueber Minimal-Pagebuilder-Modul</p>
+        <section class="pb-content">
+            <?= $this->getArticle() ?>
+        </section>
+    </main>
+</body>
+</html>`;
+}
+
+function buildMinimalPagebuilderModuleInput() {
+    return `<fieldset class="form-horizontal">
+    <div class="form-group">
+        <label class="col-sm-2 control-label">JSON-Layout</label>
+        <div class="col-sm-10">
+            <textarea class="form-control" name="REX_INPUT_VALUE[1]" rows="18"><?php echo rex_escape('REX_VALUE[1]'); ?></textarea>
+            <p class="help-block">Speichert den kompletten Seitenzustand als JSON.</p>
+        </div>
+    </div>
+</fieldset>`;
+}
+
+function buildMinimalPagebuilderModuleOutput(allowHtmlBlock = false) {
+    return `<?php
+$raw = trim(html_entity_decode(strip_tags((string) 'REX_VALUE[1]'), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+if ($raw === '') {
+    echo '<div style="padding:16px;border:1px dashed #ccc;border-radius:8px;color:#666;">Pagebuilder: Kein JSON gespeichert.</div>';
+    return;
+}
+
+$payload = json_decode($raw, true);
+if (!is_array($payload)) {
+    echo '<div style="padding:16px;border:1px solid #ef4444;border-radius:8px;color:#991b1b;background:#fee2e2;">Pagebuilder JSON ungueltig.</div>';
+    return;
+}
+
+$blocks = [];
+if (isset($payload['blocks']) && is_array($payload['blocks'])) {
+    $blocks = $payload['blocks'];
+}
+
+if ($blocks === []) {
+    echo '<div style="padding:16px;border:1px dashed #ccc;border-radius:8px;color:#666;">Pagebuilder: Keine Bloecke vorhanden.</div>';
+    return;
+}
+
+foreach ($blocks as $block) {
+    if (!is_array($block)) {
+        continue;
+    }
+
+    $type = (string) ($block['type'] ?? 'text');
+
+    if ($type === 'heading') {
+        $level = (int) ($block['level'] ?? 2);
+        if ($level < 1 || $level > 6) {
+            $level = 2;
+        }
+        $text = rex_escape((string) ($block['text'] ?? ''));
+        echo '<h' . $level . '>' . $text . '</h' . $level . '>';
+        continue;
+    }
+
+    if ($type === 'image') {
+        $src = (string) ($block['src'] ?? '');
+        $src = preg_replace('@^https?://[^/]+/media/@i', '', $src) ?? $src;
+        $src = preg_replace('@^/media/@i', '', $src) ?? $src;
+        $alt = rex_escape((string) ($block['alt'] ?? ''));
+        if ($src !== '') {
+            $url = rex_url::media($src);
+            echo '<figure><img src="' . rex_escape($url) . '" alt="' . $alt . '" style="max-width:100%;height:auto;border-radius:8px;"></figure>';
+        }
+        continue;
+    }
+
+    ${allowHtmlBlock
+        ? `if ($type === 'html') {
+        $html = (string) ($block['html'] ?? '');
+        if ($html !== '') {
+            echo rex_string::sanitizeHtml($html);
+        }
+        continue;
+    }`
+        : `if ($type === 'html') {
+        $text = nl2br(rex_escape((string) ($block['html'] ?? '')));
+        echo '<p>' . $text . '</p>';
+        continue;
+    }`}
+
+    $textRaw = (string) ($block['text'] ?? '');
+    if ($textRaw !== '') {
+        if (preg_match('/<[^>]+>/', $textRaw)) {
+            echo rex_string::sanitizeHtml($textRaw);
+        } else {
+            $text = nl2br(rex_escape($textRaw));
+            echo '<p>' . $text . '</p>';
+        }
+    }
+}`;
+}
+
+async function loadPagebuilder() {
+    const container = document.getElementById('pagebuilderContent');
+
+    const [templates, modules] = await Promise.all([
+        getTemplatesForPagebuilder(),
+        getModulesForPagebuilder(),
+    ]);
+
+    const installedTemplate = templates.find(t => (t.key || '') === PAGEBUILDER_TEMPLATE_KEY);
+    const installedModule = modules.find(m => (m.key || '') === PAGEBUILDER_MODULE_KEY);
+    const isInstalled = Boolean(installedTemplate && installedModule);
+
+    container.innerHTML = `
+        <div class="card">
+            <div class="card-header">
+                <h3>Minimaler Pagebuilder (Template + Modul)</h3>
+                <div class="filter-bar">
+                    <button class="btn-icon" onclick="installMinimalPagebuilder()">
+                        ${isInstalled ? 'Neu installieren / aktualisieren' : 'Installieren'}
+                    </button>
+                    <button class="btn-icon" onclick="copyPagebuilderDemoJson()">Demo JSON kopieren</button>
+                    <button class="btn-icon" onclick="loadPagebuilder()">Status aktualisieren</button>
+                </div>
+            </div>
+            <div class="card-body padded">
+                <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px;background:#f8fafc;border:1px solid #e2e8f0;border-radius:var(--radius-sm);padding:10px 12px;">
+                    <input id="pbSafeMode" type="checkbox">
+                    <label for="pbSafeMode" style="font-size:12px;color:var(--text-muted);">Sicherer Modus (XSS-Schutz): html-Block wird escaped statt als Raw-HTML gerendert</label>
+                </div>
+
+                <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:16px;margin-bottom:20px;">
+                    <div style="background:var(--bg-input);border:1px solid var(--border);border-radius:var(--radius-sm);padding:14px;">
+                        <div style="font-size:12px;color:var(--text-muted);">Template</div>
+                        <div style="font-size:14px;font-weight:700;margin-top:4px;">${installedTemplate ? escHtml(installedTemplate.name || 'Vorhanden') : 'Nicht installiert'}</div>
+                        <div style="font-size:12px;color:var(--text-muted);margin-top:6px;">Key: ${PAGEBUILDER_TEMPLATE_KEY}</div>
+                    </div>
+                    <div style="background:var(--bg-input);border:1px solid var(--border);border-radius:var(--radius-sm);padding:14px;">
+                        <div style="font-size:12px;color:var(--text-muted);">Modul</div>
+                        <div style="font-size:14px;font-weight:700;margin-top:4px;">${installedModule ? escHtml(installedModule.name || 'Vorhanden') : 'Nicht installiert'}</div>
+                        <div style="font-size:12px;color:var(--text-muted);margin-top:6px;">Key: ${PAGEBUILDER_MODULE_KEY}</div>
+                    </div>
+                </div>
+
+                <div style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:var(--radius-sm);padding:14px;margin-bottom:16px;">
+                    <div style="font-weight:700;font-size:13px;margin-bottom:8px;">So nutzt du den Minimal-Setup:</div>
+                    <ol style="margin:0;padding-left:20px;font-size:12px;color:var(--text-muted);line-height:1.8;">
+                        <li>Auf Installieren klicken (legt Template und Modul an).</li>
+                        <li>Artikel auf das Template mit Key ${PAGEBUILDER_TEMPLATE_KEY} setzen.</li>
+                        <li>Modul mit Key ${PAGEBUILDER_MODULE_KEY} in den Artikel einfuegen.</li>
+                        <li>In Value 1 JSON speichern, z. B. mit blocks: [] aus deinem externen Backend.</li>
+                    </ol>
+                </div>
+
+                <div style="display:grid;grid-template-columns:1fr;gap:16px;">
+                    <div>
+                        <div style="font-weight:700;font-size:13px;margin-bottom:6px;">JSON-Beispiel fuer Value 1</div>
+                        <div class="code-block">${escHtml(JSON.stringify(getPagebuilderDemoPayload(), null, 2))}</div>
+                    </div>
+                    <div style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:var(--radius-sm);padding:14px;">
+                        <div style="font-weight:700;font-size:13px;margin-bottom:8px;">Demo direkt in vorhandenen Slice schreiben</div>
+                        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px;">
+                            <div>
+                                <label style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px;">Artikel-ID</label>
+                                <input id="pbDemoArticleId" type="number" min="1" placeholder="z. B. 1">
+                            </div>
+                            <div>
+                                <label style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px;">Slice-ID</label>
+                                <input id="pbDemoSliceId" type="number" min="1" placeholder="z. B. 42">
+                            </div>
+                        </div>
+                        <div style="margin-top:10px;display:flex;gap:8px;flex-wrap:wrap;">
+                            <button class="btn-icon" onclick="applyPagebuilderDemoToSlice()">Demo in Slice schreiben</button>
+                            <span style="font-size:12px;color:var(--text-muted);">Nutzt PATCH auf structure/articles/{articleId}/slices/{sliceId} und schreibt value1.</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `;
+}
+
+async function getTemplatesForPagebuilder() {
+    if (STATE.templates.length > 0) {
+        return STATE.templates;
+    }
+    const data = await apiRequest('GET', 'templates?per_page=1000');
+    STATE.templates = unwrapListPayload(data);
+    return STATE.templates;
+}
+
+async function getModulesForPagebuilder() {
+    if (STATE.modules.length > 0) {
+        return STATE.modules;
+    }
+    const data = await apiRequest('GET', 'modules?per_page=1000');
+    STATE.modules = unwrapListPayload(data);
+    return STATE.modules;
+}
+
+async function installMinimalPagebuilder() {
+    const safeModeCheckbox = document.getElementById('pbSafeMode');
+    // Default without checkbox: allow raw HTML, safe mode only when explicitly enabled.
+    const allowHtmlBlock = safeModeCheckbox ? !safeModeCheckbox.checked : true;
+
+    const templatePayload = {
+        name: 'Minimal Pagebuilder Template',
+        key: PAGEBUILDER_TEMPLATE_KEY,
+        content: buildMinimalPagebuilderTemplateContent(),
+        active: 1,
+    };
+
+    const modulePayload = {
+        name: 'Minimal Pagebuilder Modul',
+        key: PAGEBUILDER_MODULE_KEY,
+        input: buildMinimalPagebuilderModuleInput(),
+        output: buildMinimalPagebuilderModuleOutput(allowHtmlBlock),
+    };
+
+    try {
+        const templates = await getTemplatesForPagebuilder();
+        const modules = await getModulesForPagebuilder();
+
+        const existingTemplate = templates.find(t => (t.key || '') === PAGEBUILDER_TEMPLATE_KEY);
+        const existingModule = modules.find(m => (m.key || '') === PAGEBUILDER_MODULE_KEY);
+
+        if (existingTemplate && existingTemplate.id) {
+            await apiRequest('PATCH', `templates/${existingTemplate.id}`, templatePayload);
+        } else {
+            await apiRequest('POST', 'templates', templatePayload);
+        }
+
+        if (existingModule && existingModule.id) {
+            await apiRequest('PATCH', `modules/${existingModule.id}`, modulePayload);
+        } else {
+            await apiRequest('POST', 'modules', modulePayload);
+        }
+
+        STATE.templates = [];
+        STATE.modules = [];
+        await Promise.all([loadTemplates(), loadModules()]);
+        await loadPagebuilder();
+
+        alert(`Minimaler Pagebuilder wurde erfolgreich installiert bzw. aktualisiert. Modus: ${allowHtmlBlock ? 'Raw-HTML erlaubt' : 'Sicher (kein Raw-HTML)'}`);
+    } catch (err) {
+        alert(`Installation fehlgeschlagen: ${err.message}`);
+    }
+}
+
+async function copyPagebuilderDemoJson() {
+    const demoJson = JSON.stringify(getPagebuilderDemoPayload(), null, 2);
+    try {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            await navigator.clipboard.writeText(demoJson);
+            alert('Demo JSON wurde in die Zwischenablage kopiert.');
+            return;
+        }
+    } catch (err) {
+        console.warn('Clipboard write failed', err);
+    }
+
+    showModal('Demo JSON', `<div class="code-block">${escHtml(demoJson)}</div>`);
+}
+
+async function applyPagebuilderDemoToSlice() {
+    const articleInput = document.getElementById('pbDemoArticleId');
+    const sliceInput = document.getElementById('pbDemoSliceId');
+    const articleId = Number(articleInput?.value || 0);
+    const sliceId = Number(sliceInput?.value || 0);
+
+    if (!Number.isInteger(articleId) || articleId <= 0 || !Number.isInteger(sliceId) || sliceId <= 0) {
+        alert('Bitte gueltige Artikel-ID und Slice-ID eingeben.');
+        return;
+    }
+
+    try {
+        await apiRequest('PATCH', `structure/articles/${articleId}/slices/${sliceId}`, {
+            value1: JSON.stringify(getPagebuilderDemoPayload(), null, 2),
+        });
+        alert(`Demo JSON wurde in Artikel #${articleId}, Slice #${sliceId} gespeichert.`);
+    } catch (err) {
+        alert(`Demo konnte nicht gespeichert werden: ${err.message}`);
+    }
+}
+
+async function ensureMinimalPagebuilderAssets() {
+    const templates = await getTemplatesForPagebuilder();
+    const modules = await getModulesForPagebuilder();
+    const hasTemplate = templates.some(t => (t.key || '') === PAGEBUILDER_TEMPLATE_KEY);
+    const existingModule = modules.find(m => (m.key || '') === PAGEBUILDER_MODULE_KEY);
+    const hasModule = Boolean(existingModule);
+
+    // Versionsprüfung: updatedate enthält die Version als Kommentar-Kennung im output-Feld
+    // Einfacherer Ansatz: Version in localStorage merken und bei Mismatch updaten
+    const storedVersion = parseInt(localStorage.getItem('pb_module_version') || '0', 10);
+    const needsUpdate = !hasTemplate || !hasModule || storedVersion < PAGEBUILDER_MODULE_VERSION;
+
+    if (!needsUpdate) {
+        return;
+    }
+
+    await installMinimalPagebuilder();
+    localStorage.setItem('pb_module_version', String(PAGEBUILDER_MODULE_VERSION));
+}
+
+async function findCreatedArticleIdFallback(name, parentId, clangId) {
+    const list = unwrapListPayload(await apiRequest('GET', 'structure/articles?per_page=1000'));
+    const normalizedName = String(name || '').trim().toLowerCase();
+    const filtered = list.filter(a => {
+        const sameParent = Number(a.parent_id || 0) === Number(parentId || 0);
+        const sameClang = Number(a.clang_id || clangId || 1) === Number(clangId || 1);
+        const sameName = String(a.name || '').trim().toLowerCase() === normalizedName;
+        return sameParent && sameClang && sameName;
+    });
+
+    if (filtered.length === 0) {
+        return 0;
+    }
+
+    filtered.sort((a, b) => String(b.updatedate || b.createdate || '').localeCompare(String(a.updatedate || a.createdate || '')));
+    return Number(filtered[0].id || 0);
+}
+
+async function openPagebuilderEditor(articleId, clangId = null, createSliceIfMissing = true) {
+    try {
+        await ensureMinimalPagebuilderAssets();
+        await pagebuilderEnsureMediaLoaded();
+        const modules = await getModulesForPagebuilder();
+        const pagebuilderModule = modules.find(m => (m.key || '') === PAGEBUILDER_MODULE_KEY);
+        if (!pagebuilderModule || !pagebuilderModule.id) {
+            throw new Error('Pagebuilder-Modul nicht gefunden.');
+        }
+
+        const resolvedClang = Number(clangId || STATE.currentClang || 1);
+        let slices = unwrapListPayload(await apiRequest('GET', `structure/articles/${articleId}/slices`));
+        let pagebuilderSlice = slices.find(s => Number(s.module_id) === Number(pagebuilderModule.id));
+
+        if (!pagebuilderSlice && createSliceIfMissing) {
+            const demoJson = JSON.stringify(getPagebuilderDemoPayload(), null, 2);
+            const slicePayload = {
+                module_id: Number(pagebuilderModule.id),
+                ctype_id: 1,
+                clang_id: resolvedClang,
+            };
+            const createRes = await apiRequest('POST', `structure/articles/${articleId}/slices`, slicePayload);
+            const newSliceId = Number(createRes?.slice_id || 0);
+            if (!newSliceId) {
+                throw new Error(`Slice-Erstellung fehlgeschlagen. API-Antwort: ${JSON.stringify(createRes)}`);
+            }
+            // value1 per PATCH setzen (zuverlaessiger als im POST-Body)
+            await apiRequest('PATCH', `structure/articles/${articleId}/slices/${newSliceId}`, { value1: demoJson });
+            pagebuilderSlice = { id: newSliceId, module_id: pagebuilderModule.id };
+        }
+
+        if (!pagebuilderSlice || !pagebuilderSlice.id) {
+            throw new Error('Kein Pagebuilder-Slice gefunden. Bitte ueber Slices verwalten anlegen.');
+        }
+
+        STATE.pagebuilderStatusCache[getPagebuilderStatusKey(articleId, resolvedClang)] = true;
+
+        const sliceDetail = await apiRequest('GET', `structure/articles/${articleId}/slices/${pagebuilderSlice.id}`);
+        // Falls value1 leer ist (z.B. aeltere Slices), Demo-JSON vorbefuellen
+        const storedValue = String(sliceDetail?.value1 ?? '').trim();
+        let value1 = storedValue;
+        if (!value1) {
+            value1 = JSON.stringify(getPagebuilderDemoPayload(), null, 2);
+            // Direkt speichern damit Frontend korrekt rendert
+            await apiRequest('PATCH', `structure/articles/${articleId}/slices/${pagebuilderSlice.id}`, {
+                value1,
+            });
+        } else {
+            try {
+                value1 = normalizePagebuilderJsonString(value1);
+            } catch (_) {
+                // Keep raw value on parse failure; visual editor shows the error.
+            }
+        }
+
+        const html = `<form onsubmit="submitPagebuilderValueForm(event, ${articleId}, ${pagebuilderSlice.id}, ${resolvedClang})">
+            <div class="form-group">
+                <label>Pagebuilder JSON (value1)</label>
+                <textarea name="value1" required oninput="pagebuilderRenderVisualEditor(this.form)" style="width:100%;min-height:240px;padding:12px;border-radius:var(--radius-sm);border:1px solid var(--border);background:var(--bg-input);color:var(--text);font-family:SFMono-Regular,Menlo,Monaco,Consolas,'Liberation Mono','Courier New',monospace;font-size:12px;line-height:1.5;">${escHtml(value1)}</textarea>
+            </div>
+            <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:10px;">
+                <button type="button" class="btn-icon" onclick="fillPagebuilderDemoInEditor(this.form)">Demo einfuellen</button>
+                <button type="button" class="btn-icon" onclick="formatPagebuilderEditorJson(this.form)">JSON formatieren</button>
+            </div>
+            <div style="border:1px solid var(--border);border-radius:var(--radius-sm);padding:12px;background:var(--bg-card);margin-bottom:12px;">
+                <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:10px;">
+                    <strong>Visueller Block-Editor (mini)</strong>
+                    <div style="display:flex;gap:6px;flex-wrap:wrap;">
+                        <button type="button" class="btn-icon" onclick="pagebuilderAddBlock(this.form,'heading')">+ Heading</button>
+                        <button type="button" class="btn-icon" onclick="pagebuilderAddBlock(this.form,'text')">+ Text</button>
+                        <button type="button" class="btn-icon" onclick="pagebuilderAddBlock(this.form,'image')">+ Bild</button>
+                        <button type="button" class="btn-icon" onclick="pagebuilderAddBlock(this.form,'html')">+ HTML</button>
+                    </div>
+                </div>
+                <div data-pb-visual-root></div>
+            </div>
+            <div style="display:flex; gap:12px; margin-top:24px;">
+                <button type="button" class="btn-primary" style="background:var(--bg-input); color:var(--text); border:1px solid var(--border);" onclick="showArticleDetail(${articleId})">Zurueck</button>
+                <button type="submit" class="btn-primary">Pagebuilder speichern</button>
+            </div>
+        </form>`;
+
+        showModal(`Pagebuilder Editor fuer Artikel #${articleId}`, html);
+        const pbForm = document.querySelector('#modalBody form');
+        if (pbForm) {
+            pagebuilderRenderVisualEditor(pbForm);
+        }
+    } catch (err) {
+        alert(`Pagebuilder konnte nicht geoeffnet werden: ${err.message}`);
+    }
+}
+
+function pagebuilderReadPayload(form) {
+    const raw = String(form?.value1?.value || '').trim();
+    let parsed = {};
+    if (raw) {
+        try {
+            parsed = JSON.parse(raw);
+        } catch (_) {
+            // Backward compatibility for entity-encoded payloads (&quot;, &lt;...)
+            parsed = JSON.parse(decodeHtmlEntities(raw));
+        }
+    }
+    const payload = (parsed && typeof parsed === 'object') ? parsed : {};
+    if (!Array.isArray(payload.blocks)) {
+        payload.blocks = [];
+    }
+    return normalizePagebuilderPayload(payload);
+}
+
+function decodeHtmlEntities(value) {
+    const textarea = document.createElement('textarea');
+    textarea.innerHTML = String(value || '');
+    return textarea.value;
+}
+
+function normalizePagebuilderPayload(payload) {
+    if (!payload || typeof payload !== 'object') {
+        return { blocks: [] };
+    }
+    if (!Array.isArray(payload.blocks)) {
+        payload.blocks = [];
+    }
+
+    payload.blocks = payload.blocks.map(block => {
+        if (!block || typeof block !== 'object') {
+            return block;
+        }
+        if (String(block.type || '') === 'html' && typeof block.html === 'string') {
+            return {
+                ...block,
+                html: decodeHtmlEntities(block.html),
+            };
+        }
+        return block;
+    });
+
+    return payload;
+}
+
+function normalizePagebuilderJsonString(raw) {
+    const str = String(raw || '').trim();
+    if (!str) {
+        return JSON.stringify({ blocks: [] }, null, 2);
+    }
+
+    let parsed;
+    try {
+        parsed = JSON.parse(str);
+    } catch (_) {
+        parsed = JSON.parse(decodeHtmlEntities(str));
+    }
+
+    return JSON.stringify(normalizePagebuilderPayload(parsed), null, 2);
+}
+
+function pagebuilderWritePayload(form, payload) {
+    if (!form || !form.value1) return;
+    form.value1.value = JSON.stringify(payload, null, 2);
+}
+
+function pagebuilderBlockDefaults(type) {
+    if (type === 'heading') {
+        return { type: 'heading', level: 2, text: 'Neue Ueberschrift' };
+    }
+    if (type === 'image') {
+        return { type: 'image', src: '', alt: '' };
+    }
+    if (type === 'html') {
+        return { type: 'html', html: '<p>HTML Block</p>' };
+    }
+    return { type: 'text', text: 'Neuer Textblock' };
+}
+
+function pagebuilderRenderVisualEditor(form) {
+    if (!form) return;
+    const root = form.querySelector('[data-pb-visual-root]');
+    if (!root) return;
+
+    let payload;
+    try {
+        payload = pagebuilderReadPayload(form);
+    } catch (err) {
+        root.innerHTML = `<div style="padding:10px;border:1px solid #ef4444;border-radius:6px;background:#fee2e2;color:#991b1b;">JSON ungueltig: ${escHtml(err.message)}</div>`;
+        return;
+    }
+
+    const blocks = payload.blocks;
+    const mediaOptions = (STATE.media || []).map(m => `<option value="${escAttr(String(m.filename || ''))}">${escHtml(String(m.filename || ''))}</option>`).join('');
+
+    if (blocks.length === 0) {
+        root.innerHTML = '<div style="padding:10px;border:1px dashed var(--border);border-radius:6px;color:var(--text-muted);">Noch keine Bloecke vorhanden. Ueber die Buttons oben einen Block hinzufuegen.</div>';
+        return;
+    }
+
+    root.innerHTML = blocks.map((block, index) => {
+        const type = String(block?.type || 'text');
+        const isHeading = type === 'heading';
+        const isImage = type === 'image';
+        const isHtml = type === 'html';
+        const headingLevel = Number(block?.level || 2);
+        const textValue = String(block?.text || '');
+        const srcValue = String(block?.src || '');
+        const altValue = String(block?.alt || '');
+        const htmlValue = String(block?.html || '');
+        const imagePreviewUrl = pagebuilderResolveMediaUrl(srcValue);
+
+        return `<div style="border:1px solid var(--border);border-radius:8px;padding:10px;margin-bottom:10px;background:var(--bg-input);">
+            <div style="display:flex;justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:8px;">
+                <strong>Block ${index + 1}: ${escHtml(type)}</strong>
+                <div style="display:flex;gap:6px;flex-wrap:wrap;">
+                    <button type="button" class="btn-icon" onclick="pagebuilderMoveBlock(this.form, ${index}, -1)">↑</button>
+                    <button type="button" class="btn-icon" onclick="pagebuilderMoveBlock(this.form, ${index}, 1)">↓</button>
+                    <button type="button" class="btn-icon btn-danger" onclick="pagebuilderRemoveBlock(this.form, ${index})">Entfernen</button>
+                </div>
+            </div>
+            <div class="form-group" style="margin-bottom:8px;">
+                <label>Typ</label>
+                <select onchange="pagebuilderSetBlockType(this.form, ${index}, this.value)">
+                    <option value="heading" ${isHeading ? 'selected' : ''}>heading</option>
+                    <option value="text" ${type === 'text' ? 'selected' : ''}>text</option>
+                    <option value="image" ${isImage ? 'selected' : ''}>image</option>
+                    <option value="html" ${isHtml ? 'selected' : ''}>html</option>
+                </select>
+            </div>
+            ${isHeading ? `<div style="display:grid;grid-template-columns:120px 1fr;gap:8px;">
+                <div class="form-group" style="margin-bottom:0;">
+                    <label>Level</label>
+                    <select onchange="pagebuilderSetBlockField(this.form, ${index}, 'level', this.value)">
+                        ${[1,2,3,4,5,6].map(l => `<option value="${l}" ${l === headingLevel ? 'selected' : ''}>h${l}</option>`).join('')}
+                    </select>
+                </div>
+                <div class="form-group" style="margin-bottom:0;">
+                    <label>Text</label>
+                    <input type="text" value="${escAttr(textValue)}" oninput="pagebuilderSetBlockField(this.form, ${index}, 'text', this.value)">
+                </div>
+            </div>` : ''}
+            ${type === 'text' ? `<div class="form-group" style="margin-bottom:0;">
+                <label style="display:flex;justify-content:space-between;align-items:center;gap:8px;">Text
+                    <button type="button" class="btn-icon" onclick="pagebuilderOpenQuill(this.form, ${index}, 'text')">Mit Quill bearbeiten</button>
+                </label>
+                <textarea style="min-height:90px;" oninput="pagebuilderSetBlockField(this.form, ${index}, 'text', this.value)">${escHtml(textValue)}</textarea>
+            </div>` : ''}
+            ${isImage ? `<div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;">
+                <div class="form-group" style="margin-bottom:0;">
+                    <label>Dateiname (src)</label>
+                    <input type="text" placeholder="bild.jpg oder /media/bild.jpg" value="${escAttr(srcValue)}" oninput="pagebuilderSetBlockField(this.form, ${index}, 'src', this.value)">
+                    <div style="margin-top:6px;display:flex;gap:6px;align-items:center;">
+                        <select onchange="pagebuilderUseMediaFromSelect(this.form, ${index}, this.value)">
+                            <option value="">Aus Medienpool waehlen…</option>
+                            ${mediaOptions}
+                        </select>
+                    </div>
+                </div>
+                <div class="form-group" style="margin-bottom:0;">
+                    <label>Alt-Text</label>
+                    <input type="text" value="${escAttr(altValue)}" oninput="pagebuilderSetBlockField(this.form, ${index}, 'alt', this.value)">
+                </div>
+            </div>
+            <div style="margin-top:8px;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg-card);">
+                <div style="font-size:12px;color:var(--text-muted);margin-bottom:6px;">Vorschau-URL: ${imagePreviewUrl ? `<a href="${escAttr(imagePreviewUrl)}" target="_blank" rel="noopener">${escHtml(imagePreviewUrl)}</a>` : '–'}</div>
+                ${imagePreviewUrl ? `<img src="${escAttr(imagePreviewUrl)}" alt="${escAttr(altValue || 'Preview')}" style="max-width:100%;max-height:180px;border-radius:6px;border:1px solid var(--border);" onerror="this.style.display='none'; this.nextElementSibling.style.display='block';"><div style="display:none;color:var(--text-muted);font-size:12px;">Bild konnte remote nicht geladen werden.</div>` : `<div style="color:var(--text-muted);font-size:12px;">Kein Bild gewaehlt</div>`}
+            </div>` : ''}
+            ${isHtml ? `<div class="form-group" style="margin-bottom:0;">
+                <label style="display:flex;justify-content:space-between;align-items:center;gap:8px;">HTML
+                    <button type="button" class="btn-icon" onclick="pagebuilderOpenQuill(this.form, ${index}, 'html')">Mit Quill bearbeiten</button>
+                </label>
+                <textarea style="min-height:90px;" oninput="pagebuilderSetBlockField(this.form, ${index}, 'html', this.value)">${escHtml(htmlValue)}</textarea>
+            </div>` : ''}
+        </div>`;
+    }).join('');
+}
+
+function pagebuilderResolveMediaUrl(src) {
+    const raw = String(src || '').trim();
+    if (!raw) return '';
+    if (/^https?:\/\//i.test(raw)) return raw;
+    if (raw.startsWith('/media/')) return `${CONFIG.url}${raw}`;
+    return `${CONFIG.url}/media/${raw.split('/').map(encodeURIComponent).join('/')}`;
+}
+
+async function pagebuilderEnsureMediaLoaded() {
+    if (Array.isArray(STATE.media) && STATE.media.length > 0) {
+        return;
+    }
+    try {
+        STATE.media = unwrapListPayload(await apiRequest('GET', 'media?per_page=1000'));
+    } catch (_) {
+        STATE.media = [];
+    }
+}
+
+function pagebuilderUseMediaFromSelect(form, index, filename) {
+    if (!filename) return;
+    pagebuilderSetBlockField(form, index, 'src', `/media/${filename}`);
+    pagebuilderRenderVisualEditor(form);
+}
+
+function pagebuilderOpenQuill(form, index, field) {
+    if (!form) return;
+    if (typeof window.Quill === 'undefined') {
+        alert('Quill ist noch nicht geladen. Bitte Seite neu laden.');
+        return;
+    }
+
+    const payload = pagebuilderReadPayload(form);
+    const block = payload.blocks[index] || {};
+    const initial = String(block[field] || '');
+
+    pagebuilderCloseQuillOverlay();
+
+    const overlay = document.createElement('div');
+    overlay.id = 'pbQuillOverlay';
+    overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.45);z-index:9999;display:flex;align-items:center;justify-content:center;padding:16px;';
+    overlay.innerHTML = `
+        <div style="width:min(920px,96vw);max-height:92vh;overflow:auto;background:var(--bg-card);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:12px;box-shadow:var(--shadow-lg);">
+            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">
+                <strong>Quill Editor: ${escHtml(field)} (Block ${index + 1})</strong>
+                <button type="button" class="btn-icon" onclick="pagebuilderCloseQuillOverlay()">Schliessen</button>
+            </div>
+            <div id="pbQuillEditor" style="height:320px;background:#fff;color:#111;"></div>
+            <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:12px;">
+                <button type="button" class="btn-icon" onclick="pagebuilderCloseQuillOverlay()">Abbrechen</button>
+                <button type="button" class="btn-primary" id="pbQuillSaveBtn">Uebernehmen</button>
+            </div>
+        </div>`;
+    document.body.appendChild(overlay);
+
+    const quill = new window.Quill('#pbQuillEditor', {
+        theme: 'snow',
+        modules: {
+            toolbar: [['bold', 'italic', 'underline'], [{ 'list': 'ordered' }, { 'list': 'bullet' }], ['link'], ['clean']],
+        },
+    });
+
+    if (field === 'html' || field === 'text') {
+        quill.clipboard.dangerouslyPasteHTML(initial || '');
+    } else {
+        quill.setText(initial || '');
+    }
+
+    const saveBtn = document.getElementById('pbQuillSaveBtn');
+    if (saveBtn) {
+        saveBtn.onclick = () => {
+            const value = (field === 'html' || field === 'text')
+                ? quill.root.innerHTML
+                : quill.getText().replace(/\n$/, '');
+            pagebuilderSetBlockField(form, index, field, value);
+            pagebuilderRenderVisualEditor(form);
+            pagebuilderCloseQuillOverlay();
+        };
+    }
+}
+
+function pagebuilderCloseQuillOverlay() {
+    const overlay = document.getElementById('pbQuillOverlay');
+    if (overlay) {
+        overlay.remove();
+    }
+}
+
+function pagebuilderAddBlock(form, type) {
+    if (!form) return;
+    try {
+        const payload = pagebuilderReadPayload(form);
+        payload.blocks.push(pagebuilderBlockDefaults(type));
+        pagebuilderWritePayload(form, payload);
+        pagebuilderRenderVisualEditor(form);
+    } catch (err) {
+        alert(`Block konnte nicht hinzugefuegt werden: ${err.message}`);
+    }
+}
+
+function pagebuilderRemoveBlock(form, index) {
+    if (!form) return;
+    try {
+        const payload = pagebuilderReadPayload(form);
+        payload.blocks.splice(index, 1);
+        pagebuilderWritePayload(form, payload);
+        pagebuilderRenderVisualEditor(form);
+    } catch (err) {
+        alert(`Block konnte nicht entfernt werden: ${err.message}`);
+    }
+}
+
+function pagebuilderMoveBlock(form, index, direction) {
+    if (!form) return;
+    try {
+        const payload = pagebuilderReadPayload(form);
+        const target = index + direction;
+        if (target < 0 || target >= payload.blocks.length) return;
+        const current = payload.blocks[index];
+        payload.blocks[index] = payload.blocks[target];
+        payload.blocks[target] = current;
+        pagebuilderWritePayload(form, payload);
+        pagebuilderRenderVisualEditor(form);
+    } catch (err) {
+        alert(`Block konnte nicht verschoben werden: ${err.message}`);
+    }
+}
+
+function pagebuilderSetBlockType(form, index, newType) {
+    if (!form) return;
+    try {
+        const payload = pagebuilderReadPayload(form);
+        payload.blocks[index] = pagebuilderBlockDefaults(newType);
+        pagebuilderWritePayload(form, payload);
+        pagebuilderRenderVisualEditor(form);
+    } catch (err) {
+        alert(`Block-Typ konnte nicht geaendert werden: ${err.message}`);
+    }
+}
+
+function pagebuilderSetBlockField(form, index, field, value) {
+    if (!form) return;
+    try {
+        const payload = pagebuilderReadPayload(form);
+        if (!payload.blocks[index] || typeof payload.blocks[index] !== 'object') return;
+        payload.blocks[index][field] = field === 'level' ? Number(value || 2) : value;
+        pagebuilderWritePayload(form, payload);
+    } catch (err) {
+        alert(`Block-Wert konnte nicht geaendert werden: ${err.message}`);
+    }
+}
+
+function fillPagebuilderDemoInEditor(form) {
+    if (!form || !form.value1) return;
+    form.value1.value = JSON.stringify(getPagebuilderDemoPayload(), null, 2);
+    pagebuilderRenderVisualEditor(form);
+}
+
+function formatPagebuilderEditorJson(form) {
+    if (!form || !form.value1) return;
+    try {
+        form.value1.value = normalizePagebuilderJsonString(form.value1.value || '{}');
+        pagebuilderRenderVisualEditor(form);
+    } catch (err) {
+        alert(`JSON ist ungueltig: ${err.message}`);
+    }
+}
+
+async function submitPagebuilderValueForm(e, articleId, sliceId, clangId) {
+    e.preventDefault();
+    const form = e.target;
+    const btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.textContent = 'Speichert…';
+
+    try {
+        const normalizedJson = normalizePagebuilderJsonString(form.value1.value || '{}');
+        form.value1.value = normalizedJson;
+        await apiRequest('PATCH', `structure/articles/${articleId}/slices/${sliceId}`, {
+            value1: normalizedJson,
+        });
+        STATE.pagebuilderStatusCache[getPagebuilderStatusKey(articleId, clangId)] = true;
+        btn.textContent = 'Gespeichert';
+        setTimeout(() => {
+            btn.disabled = false;
+            btn.textContent = 'Pagebuilder speichern';
+        }, 700);
+    } catch (err) {
+        alert(`Pagebuilder konnte nicht gespeichert werden: ${err.message}`);
+        btn.disabled = false;
+        btn.textContent = 'Pagebuilder speichern';
+    }
+}
+
+// ==================== API REPORT ====================
+
+async function loadApiReport() {
+    const container = document.getElementById('apiReportContent');
+    container.innerHTML = `
+        <div class="card">
+            <div class="card-header">
+                <h3>✅ Verfügbare API-Endpunkte</h3>
+            </div>
+            <div class="card-body padded">
+                <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 20px;">
+                    ${renderEndpointGroups()}
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header">
+                <h3>⚠️ Fehlende Features für komplette Website-Verwaltung</h3>
+            </div>
+            <div class="card-body padded">
+                ${renderMissingFeatures()}
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header">
+                <h3>📊 Zusammenfassung</h3>
+            </div>
+            <div class="card-body padded">
+                ${renderSummary()}
+            </div>
+        </div>
+    `;
+}
+
+function renderEndpointGroups() {
+    const groups = {
+        '📄 Struktur': [
+            '✅ GET /structure/articles — Artikelübersicht',
+            '✅ GET /structure/articles/{id} — Artikel abrufen',
+            '✅ POST /structure/articles — Artikel erstellen',
+            '✅ PATCH /structure/articles/{id} — Artikel aktualisieren',
+            '✅ DELETE /structure/articles/{id} — Artikel löschen',
+            '✅ POST /structure/categories — Kategorie erstellen',
+            '✅ PATCH /structure/categories/{id} — Kategorie aktualisieren',
+            '✅ DELETE /structure/categories/{id} — Kategorie löschen',
+            '✅ GET /structure/articles/{id}/slices — Slices abrufen',
+            '✅ POST /structure/articles/{id}/slices — Slice erstellen',
+            '✅ PATCH /structure/articles/{id}/slices/{slice_id} — Slice aktualisieren',
+            '✅ DELETE /structure/articles/{id}/slices/{slice_id} — Slice löschen',
+        ],
+        '📸 Medienpool': [
+            '✅ GET /media — Medienliste',
+            '✅ GET /media/{filename}/info — Medieninfo',
+            '✅ GET /media/{filename}/file — Datei herunterladen',
+            '✅ POST /media — Datei hochladen',
+            '✅ PATCH /media/{filename}/update — Datei aktualisieren',
+            '✅ DELETE /media/{filename}/delete — Datei löschen',
+            '✅ GET /media/category — Kategorien abrufen',
+            '✅ POST /media/category — Kategorie erstellen',
+            '✅ PATCH /media/category/{id} — Kategorie aktualisieren',
+            '✅ DELETE /media/category/{id} — Kategorie löschen',
+        ],
+        '🎨 Templates & Module': [
+            '✅ GET /templates — Template-Übersicht',
+            '✅ GET /templates/{id} — Template abrufen',
+            '✅ POST /templates — Template erstellen',
+            '✅ PATCH /templates/{id} — Template aktualisieren',
+            '✅ DELETE /templates/{id} — Template löschen',
+            '✅ GET /modules — Modul-Übersicht',
+            '✅ GET /modules/{id} — Modul abrufen',
+            '✅ POST /modules — Modul erstellen',
+            '✅ PATCH /modules/{id} — Modul aktualisieren',
+            '✅ DELETE /modules/{id} — Modul löschen',
+        ],
+        '👥 Benutzer & Rollen': [
+            '✅ GET /users — Benutzerliste',
+            '✅ GET /users/{id} — Benutzer abrufen',
+            '✅ POST /users — Benutzer erstellen',
+            '✅ PATCH /users/{id} — Benutzer aktualisieren',
+            '✅ DELETE /users/{id} — Benutzer löschen',
+            '✅ GET /users/roles — Rollenliste',
+            '✅ GET /users/roles/{id} — Rolle abrufen',
+            '✅ POST /users/roles — Rolle erstellen',
+            '✅ PATCH /users/roles/{id} — Rolle aktualisieren',
+            '✅ DELETE /users/roles/{id} — Rolle löschen',
+            '✅ POST /users/{id}/role/{role_id} — Rolle zuweisen',
+            '✅ DELETE /users/{id}/role/{role_id} — Rolle entfernen',
+        ],
+        '🌍 System': [
+            '✅ GET /system/clangs — Sprachenliste',
+            '✅ GET /system/clangs/{id} — Sprache abrufen',
+            '✅ POST /system/clangs — Sprache erstellen',
+            '✅ PATCH /system/clangs/{id} — Sprache aktualisieren',
+            '✅ DELETE /system/clangs/{id} — Sprache löschen',
+        ],
+        '🏷️ Metainfo': [
+            '✅ GET /metainfo/types — Metafeld-Typen',
+            '✅ GET /metainfo/fields — Metafelder',
+            '✅ GET /metainfo/fields/{id} — Metafeld abrufen',
+            '✅ POST /metainfo/fields — Metafeld erstellen',
+            '✅ PATCH /metainfo/fields/{id} — Metafeld aktualisieren',
+            '✅ DELETE /metainfo/fields/{id} — Metafeld löschen',
+            '✅ GET /structure/articles/{id}/metainfo — Artikel-Metainfo',
+            '✅ PATCH /structure/articles/{id}/metainfo — Artikel-Metainfo aktualisieren',
+            '✅ GET /media/{filename}/metainfo — Medien-Metainfo',
+            '✅ PATCH /media/{filename}/metainfo — Medien-Metainfo aktualisieren',
+        ],
+    };
+
+    return Object.entries(groups).map(([title, endpoints]) => `
+        <div style="background: var(--bg-input); padding: 16px; border-radius: var(--radius-sm); border: 1px solid var(--border);">
+            <h4 style="margin-top:0; color: var(--primary); font-size: 14px; font-weight: 700; margin-bottom: 12px;">${title}</h4>
+            <ul style="margin: 0; padding: 0; list-style: none; font-size: 12px; color: var(--text-muted); line-height: 1.6;">
+                ${endpoints.map(e => `<li>• ${e}</li>`).join('')}
+            </ul>
+        </div>
+    `).join('');
+}
+
+function renderMissingFeatures() {
+    const features = [
+        {
+            cat: '🔧 Addon-Management',
+            items: [
+                '❌ GET /addons — Addon-Liste (Installed/Active Status)',
+                '❌ PATCH /addons/{id}/status — Addon aktivieren/deaktivieren',
+                '❌ GET /addons/{id} — Addon-Details (Version, Dependencies)',
+            ]
+        },
+        {
+            cat: '💾 Cache-Management',
+            items: [
+                '❌ GET /cache/status — Cache-Größe, Last Rebuild Zeit',
+                '❌ DELETE /cache/all — Alle Caches leeren',
+                '❌ DELETE /cache/{type} — Spezifischen Cache leeren (DB, Templates, etc)',
+            ]
+        },
+        {
+            cat: '📋 System-Information',
+            items: [
+                '❌ GET /system/info — PHP Version, Memory Limit, REDAXO Version',
+                '❌ GET /system/disk — Disk Space Info',
+                '❌ GET /system/database — DB-Größe, Tabellen-Anzahl',
+                '❌ GET /system/health — System Health Status',
+            ]
+        },
+        {
+            cat: '❌ Fehler-Management',
+            items: [
+                '❌ GET /system/error-log — Fehlerlog abrufen (mit Filter, Pagination)',
+                '❌ DELETE /system/error-log — Errorlog leeren',
+            ]
+        },
+        {
+            cat: '📁 Fragment-Management',
+            items: [
+                '❌ GET /fragments — Fragment-Liste',
+                '❌ GET /fragments/{id} — Fragment abrufen',
+                '❌ POST /fragments — Fragment erstellen',
+                '❌ PATCH /fragments/{id} — Fragment aktualisieren',
+                '❌ DELETE /fragments/{id} — Fragment löschen',
+            ]
+        },
+        {
+            cat: '🔗 Link-Management',
+            items: [
+                '❌ GET /linklist/{id} — Linklist-Werte abrufen',
+                '❌ PATCH /linklist/{id} — Linklist-Werte aktualisieren',
+            ]
+        },
+        {
+            cat: '📊 Datenbank-Tables (YForm/Custom)',
+            items: [
+                '❌ GET /tables — Tabellenliste',
+                '❌ GET /tables/{name}/rows — Zeilen abrufen',
+                '❌ POST /tables/{name}/rows — Zeile erstellen',
+                '❌ PATCH /tables/{name}/rows/{id} — Zeile aktualisieren',
+                '❌ DELETE /tables/{name}/rows/{id} — Zeile löschen',
+            ]
+        },
+        {
+            cat: '⚙️ Global Settings / REX_VARS',
+            items: [
+                '❌ GET /settings — Global Settings abrufen',
+                '❌ PATCH /settings — Global Settings aktualisieren',
+            ]
+        },
+        {
+            cat: '🔐 Authentication',
+            items: [
+                '⚠️ Nur Bearer Token Auth implementiert',
+                '❌ Backend-User Session Management',
+                '❌ Token Refresh / Expiration Management',
+            ]
+        },
+        {
+            cat: '📤 Backup / Export',
+            items: [
+                '❌ GET /backup — Backups auflisten',
+                '❌ POST /backup — Backup erstellen',
+                '❌ DELETE /backup/{id} — Backup löschen',
+                '❌ POST /export/database — DB exportieren (SQL)',
+                '❌ POST /export/articles — Artikel exportieren (XML/JSON)',
+            ]
+        },
+    ];
+
+    return features.map(group => `
+        <div style="margin-bottom: 20px;">
+            <h4 style="color: var(--text); font-size: 14px; font-weight: 700; margin-top: 0; margin-bottom: 8px;">${group.cat}</h4>
+            <ul style="margin: 0; padding-left: 20px; font-size: 12px; color: var(--text-muted); line-height: 1.8;">
+                ${group.items.map(item => `<li>${item}</li>`).join('')}
+            </ul>
+        </div>
+    `).join('');
+}
+
+function renderSummary() {
+    return `
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 16px; margin-bottom: 20px;">
+            <div style="background: var(--bg-input); padding: 16px; border-radius: var(--radius-sm); border: 1px solid var(--border);">
+                <div style="font-size: 32px; font-weight: 800; color: #10b981;">69</div>
+                <div style="font-size: 12px; color: var(--text-muted); margin-top: 4px;">✅ Implementierte Endpunkte</div>
+            </div>
+            <div style="background: var(--bg-input); padding: 16px; border-radius: var(--radius-sm); border: 1px solid var(--border);">
+                <div style="font-size: 32px; font-weight: 800; color: #ef4444;">35+</div>
+                <div style="font-size: 12px; color: var(--text-muted); margin-top: 4px;">❌ Fehlende Endpunkte</div>
+            </div>
+            <div style="background: var(--bg-input); padding: 16px; border-radius: var(--radius-sm); border: 1px solid var(--border);">
+                <div style="font-size: 32px; font-weight: 800; color: #f59e0b;">66%</div>
+                <div style="font-size: 12px; color: var(--text-muted); margin-top: 4px;">Fertigstellung (grob)</div>
+            </div>
+        </div>
+
+        <div style="background: #fef3c7; border: 1px solid #fcd34d; border-radius: var(--radius-sm); padding: 16px; margin-bottom: 20px;">
+            <div style="font-weight: 700; color: #92400e; margin-bottom: 8px;">📌 Priorisierung für Vollständigkeit:</div>
+            <ol style="margin: 0; padding-left: 20px; font-size: 12px; color: #92400e; line-height: 1.8;">
+                <li><strong>1. Addon-Management</strong> — Für Remote-Verwaltung essentiell</li>
+                <li><strong>2. System-Info & Health</strong> — Für Support & Diagnostik</li>
+                <li><strong>3. Fehler-Management</strong> — Für Troubleshooting</li>
+                <li><strong>4. YForm/Custom Tables</strong> — Für Datenmanagement</li>
+                <li><strong>5. Cache-Management</strong> — Für Performance-Tuning</li>
+                <li><strong>6. Fragment-Management</strong> — Für Layout-Verwaltung</li>
+                <li><strong>7. Backup/Export</strong> — Für Datensicherung</li>
+            </ol>
+        </div>
+
+        <div style="background: var(--bg-input); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 16px;">
+            <div style="font-weight: 700; color: var(--text); margin-bottom: 8px;">💡 Status:</div>
+            <div style="font-size: 12px; color: var(--text-muted); line-height: 1.8;">
+                Der API AddOn bietet bereits eine <strong>solide Basis</strong> für Content-Management (Struktur, Templates, Module, Medien, Benutzer).<br><br>
+                Für einen <strong>kompletten Backend-Ersatz</strong> werden hauptsächlich <strong>Addon-Management, System-Monitoring und Fehlerbehandlung</strong> benötigt.<br><br>
+                Die <strong>Implementierung der Top-3 fehlenden Features</strong> würde ca. <strong>70-80% Funktionalität</strong> erreichen.
+            </div>
+        </div>
+
+        <div style="background: #eff6ff; border: 1px solid #bfdbfe; border-radius: var(--radius-sm); padding: 16px; margin-top: 20px;">
+            <div style="font-weight: 700; color: #1e3a8a; margin-bottom: 8px;">✅ Fazit:</div>
+            <div style="font-size: 12px; color: #1e40af; line-height: 1.8;">
+                Mit dem aktuellen Stand ist eine <strong>Headless-First-Strategie</strong> sehr empfehlenswert:<br>
+                REDAXO liefert die stabilen Grundfunktionen (Struktur, Medien, Benutzer, Rechte, Sprachen),
+                während projektspezifische Features über <strong>eigene externe API-Erweiterungen</strong> umgesetzt werden.<br><br>
+                Dadurch bleibt das System flexibel, updatefähig und unabhängig von einem vollständigen Backend-Nachbau.
+            </div>
+        </div>
+
+        <div style="background: #f0fdf4; border: 1px solid #bbf7d0; border-radius: var(--radius-sm); padding: 16px; margin-top: 20px;">
+            <div style="font-weight: 700; color: #14532d; margin-bottom: 8px;">🛠️ Empfehlung: So arbeitet ihr jetzt am besten</div>
+            <ol style="margin: 0; padding-left: 20px; font-size: 12px; color: #166534; line-height: 1.9;">
+                <li><strong>Content über bestehende Core-Endpunkte pflegen</strong> (Struktur, Medien, Templates, Module, Benutzer).</li>
+                <li><strong>Eigene Features als separate API-Route-Packages bauen</strong> statt im Dashboard-UI zu verstecken.</li>
+                <li><strong>API-Verträge stabil halten</strong>: einheitliche Antwortformate, Pagination, Filter, Fehlerobjekte.</li>
+                <li><strong>Addons optional anbinden</strong>: nur wenn ein Addon einen klaren API-Mehrwert liefert.</li>
+                <li><strong>Nächste Pflicht-Endpunkte priorisieren</strong>: Addon-Management, System/Health, Error-Log, Cache.</li>
+                <li><strong>Dashboard als Control-Plane nutzen</strong>: Monitoring + Betrieb + Wartung, nicht nur CRUD.</li>
+            </ol>
+        </div>
+    `;
+}
+
+// ==================== THEME ====================
+
+function toggleTheme() {
+    const current = document.documentElement.getAttribute('data-theme');
+    const next = current === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+}
+
+(function initTheme() {
+    const saved = localStorage.getItem('rex_api_theme') || localStorage.getItem('cp_theme');
+    if (saved) {
+        setTheme(saved);
+    }
+    else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        setTheme('dark');
+    }
+})();
+
+// ==================== DASHBOARD ====================
+
+async function loadDashboard() {
+    // Show base URL in hero
+    const heroUrl = document.getElementById('heroUrl');
+
+    try {
+        const [articlesRes, mediaRes, templatesRes, modulesRes, usersRes, clangsRes] = await Promise.all([
+            apiRequest('GET', 'structure/articles?per_page=500'),
+            apiRequest('GET', 'media?per_page=500'),
+            apiRequest('GET', 'templates'),
+            apiRequest('GET', 'modules'),
+            apiRequest('GET', 'users'),
+            apiRequest('GET', 'system/clangs'),
+        ]);
+
+        STATE.articles = unwrapListPayload(articlesRes);
+        STATE.media = unwrapListPayload(mediaRes);
+        STATE.templates = unwrapListPayload(templatesRes);
+        STATE.modules = unwrapListPayload(modulesRes);
+        STATE.users = unwrapListPayload(usersRes);
+        STATE.clangs = unwrapListPayload(clangsRes);
+
+        // Set default clang
+        if (STATE.clangs.length > 0) {
+            STATE.currentClang = STATE.clangs[0].id;
+        }
+
+        // Update stats
+        const setVal = (id, val) => { const el = document.getElementById(id); if (el) el.textContent = val; };
+        setVal('statArticles', STATE.articles.length);
+        setVal('statMedia', STATE.media.length);
+        setVal('statTemplates', STATE.templates.length);
+        setVal('statModules', STATE.modules.length);
+        setVal('statUsers', STATE.users.length);
+        setVal('statClangs', STATE.clangs.length);
+
+        // Update badges
+        setVal('badgeArticles', STATE.articles.length);
+        setVal('badgeMedia', STATE.media.length);
+        setVal('badgeTemplates', STATE.templates.length);
+        setVal('badgeModules', STATE.modules.length);
+        setVal('badgeUsers', STATE.users.length);
+        setVal('badgeClangs', STATE.clangs.length);
+
+        // Hero subtitle with online article count
+        const onlineCount = STATE.articles.filter(a => a.status == 1).length;
+        const subtitle = document.getElementById('heroDashSubtitle');
+        if (subtitle) {
+            subtitle.textContent = `${STATE.articles.length} Artikel (${onlineCount} online) · ${STATE.media.length} Medien · ${STATE.clangs.length} Sprache${STATE.clangs.length !== 1 ? 'n' : ''}`;
+        }
+        // Show base URL
+        if (heroUrl) {
+            heroUrl.textContent = (CONFIG.url || window.location.origin).replace(/\/api$/, '');
+        }
+
+        // Recent articles & media
+        renderRecentArticles();
+        renderRecentMedia();
+    } catch (err) {
+        console.error('Dashboard load error:', err);
+    }
+}
+
+function renderRecentArticles() {
+    const container = document.getElementById('recentArticles');
+    const sorted = [...STATE.articles]
+        .sort((a, b) => (b.updatedate || b.createdate || '').localeCompare(a.updatedate || a.createdate || ''))
+        .slice(0, 8);
+
+    if (sorted.length === 0) {
+        container.innerHTML = '<div class="empty-state"><p>Keine Artikel gefunden</p></div>';
+        return;
+    }
+
+    container.innerHTML = sorted.map(a => {
+        const date = formatDate(a.updatedate || a.createdate);
+        const statusPill = a.status
+            ? '<span class="pill online">Online</span>'
+            : '<span class="pill offline">Offline</span>';
+        return `<div class="activity-item" onclick="showArticleDetail(${a.id})" style="cursor:pointer">
+            <div class="activity-thumb">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/></svg>
+            </div>
+            <div class="activity-info">
+                <div class="activity-title">${escHtml(a.name)}</div>
+                <div class="activity-meta">ID ${a.id} · ${date}</div>
+            </div>
+            <div class="activity-badge">${statusPill}</div>
+        </div>`;
+    }).join('');
+}
+
+function renderRecentMedia() {
+    const container = document.getElementById('recentMedia');
+    const sorted = [...STATE.media]
+        .sort((a, b) => (b.createdate || '').localeCompare(a.createdate || ''))
+        .slice(0, 8);
+
+    if (sorted.length === 0) {
+        container.innerHTML = '<div class="empty-state"><p>Keine Medien gefunden</p></div>';
+        return;
+    }
+
+    const isImage = ft => ft && /^image\//i.test(ft);
+    const mediaBase = (CONFIG.url || '').replace(/\/api$/, '');
+
+    container.innerHTML = sorted.map(m => {
+        const thumb = isImage(m.filetype)
+            ? `<img src="${escAttr(mediaBase + '/media/' + m.filename)}" alt="" loading="lazy" onerror="this.style.display='none'">`
+            : `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>`;
+        return `<div class="activity-item" onclick="showMediaDetail('${escAttr(m.filename)}')" style="cursor:pointer">
+            <div class="activity-thumb">${thumb}</div>
+            <div class="activity-info">
+                <div class="activity-title">${escHtml(m.filename)}</div>
+                <div class="activity-meta">${escHtml(shortType(m.filetype))} · ${formatSize(m.filesize)} · ${formatDate(m.createdate)}</div>
+            </div>
+        </div>`;
+    }).join('');
+}
+
+// ==================== STRUCTURE ====================
+
+async function showCreateModal(parentId = 0) {
+    // Ensure templates are loaded for selection
+    if (STATE.templates.length === 0) {
+        try {
+            await loadTemplates();
+        } catch (e) {
+            console.error('Could not load templates', e);
+        }
+    }
+
+    const parentName = parentId === 0 ? 'Root' : (STATE.articles.find(a => a.id === parentId)?.name || `ID ${parentId}`);
+
+    // Pre-calculate siblings for priority dropdown
+    const currentClang = STATE.currentClang || 1;
+    const siblings = STATE.articles.filter(a => {
+        // Only items in same parent and same clang
+        if (a.clang_id && a.clang_id != currentClang) return false;
+        return (a.parent_id || 0) == parentId;
+    });
+
+    // Helper to generate options
+    const getPrioOptions = (type) => { // 'article' or 'category'
+        const isCat = type === 'category';
+        // Filter siblings by type
+        // Categories have startarticle=1, Articles have startarticle=0
+        const filtered = siblings.filter(a => isCat ? a.startarticle == 1 : a.startarticle == 0);
+        
+        // Sort by existing priority
+        filtered.sort((a,b) => {
+            const pA = isCat ? (a.catpriority || 0) : (a.priority || 0);
+            const pB = isCat ? (b.catpriority || 0) : (b.priority || 0);
+            return pA - pB;
+        });
+
+        let opts = `<option value="1">Am Anfang</option>`;
+        filtered.forEach(s => {
+            const prio = isCat ? (s.catpriority || 0) : (s.priority || 0);
+            opts += `<option value="${prio + 1}">Nach: ${escHtml(s.name)}</option>`;
+        });
+        return opts;
+    };
+
+    const articleOptions = getPrioOptions('article');
+    const categoryOptions = getPrioOptions('category');
+
+    // Create a unique ID for the select to update it
+    const prioSelectId = 'prioSelect_' + Date.now();
+    const typeSelectId = 'typeSelect_' + Date.now();
+
+    const pagebuilderHintId = 'pagebuilderHint_' + Date.now();
+
+    const html = `
+    <form onsubmit="handleCreate(event)">
+        <input type="hidden" name="parent_id" value="${parentId}">
+        
+        <div class="form-group">
+            <label>Eltern-Kategorie</label>
+            <input type="text" value="${escHtml(parentName)}" disabled style="opacity:0.7">
+        </div>
+
+        <div class="form-group">
+            <label>Typ</label>
+            <select name="type" id="${typeSelectId}" required>
+                <option value="article">Artikel</option>
+                <option value="category">Kategorie</option>
+            </select>
+        </div>
+
+        <div class="form-group">
+            <label>Name</label>
+            <input type="text" name="name" required placeholder="Titel des Artikels/Kategorie" autofocus>
+        </div>
+
+        <div class="form-group">
+            <label>Template</label>
+            <select name="template_id" id="createTemplateSelect">
+                <option value="">(Kein Template)</option>
+                ${STATE.templates.map(t => `<option value="${t.id}">${escHtml(t.name)} [${t.id}]</option>`).join('')}
+            </select>
+        </div>
+
+        <div class="form-group" id="${pagebuilderHintId}">
+            <div style="display:flex;align-items:flex-start;gap:10px;padding:12px;border-radius:var(--radius-sm);border:1px solid var(--border);background:var(--bg-input);">
+                <input type="checkbox" name="pagebuilder_mode" id="pbModeCheckbox" value="1" style="width:16px;height:16px;margin-top:2px;flex-shrink:0;accent-color:var(--accent);">
+                <div>
+                    <label for="pbModeCheckbox" style="font-weight:600;cursor:pointer;display:block;margin-bottom:2px;">Als Pagebuilder-Seite anlegen</label>
+                    <div style="font-size:12px;color:var(--text-muted);">Template + Modul werden automatisch installiert, Editor öffnet direkt.</div>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label>Position / Priorität</label>
+            <select name="priority" id="${prioSelectId}">
+                <!-- Populated by JS -->
+            </select>
+        </div>
+
+        <div class="form-group">
+            <label>Status</label>
+            <select name="status">
+                <option value="0">Offline</option>
+                <option value="1" selected>Online</option>
+            </select>
+        </div>
+
+        <div style="display:flex; gap:12px; margin-top:24px;">
+            <button type="button" class="btn-primary" style="background:var(--bg-input); color:var(--text); border:1px solid var(--border);" onclick="closeModal()">Abbrechen</button>
+            <button type="submit" class="btn-primary">Erstellen</button>
+        </div>
+    </form>
+    `;
+
+    showModal(`Neu erstellen in ${parentName}`, html);
+
+    // Initial population and event binding (since script tags in innerHTML don't execute)
+    const typeSelect = document.getElementById(typeSelectId);
+    const prioSelect = document.getElementById(prioSelectId);
+    const templateSelect = document.getElementById('createTemplateSelect');
+    const pagebuilderCheckbox = document.querySelector('input[name="pagebuilder_mode"]');
+    const pagebuilderHint = document.getElementById(pagebuilderHintId);
+    let previousTemplateValue = templateSelect ? templateSelect.value : '';
+
+    const pagebuilderTemplate = STATE.templates.find(t => (t.key || '') === PAGEBUILDER_TEMPLATE_KEY);
+    
+    const updatePrio = () => {
+        const val = typeSelect.value;
+        prioSelect.innerHTML = val === 'article' ? articleOptions : categoryOptions;
+
+        const isArticle = val === 'article';
+        if (pagebuilderHint) {
+            pagebuilderHint.style.display = isArticle ? '' : 'none';
+        }
+        if (!isArticle && pagebuilderCheckbox) {
+            pagebuilderCheckbox.checked = false;
+        }
+        if (!isArticle && templateSelect) {
+            templateSelect.disabled = false;
+        }
+    };
+
+    const updatePagebuilderState = () => {
+        if (!templateSelect || !pagebuilderCheckbox) return;
+        if (pagebuilderCheckbox.checked) {
+            previousTemplateValue = templateSelect.value;
+            if (pagebuilderTemplate && pagebuilderTemplate.id) {
+                templateSelect.value = String(pagebuilderTemplate.id);
+            }
+            templateSelect.disabled = true;
+        } else {
+            templateSelect.disabled = false;
+            if (previousTemplateValue !== undefined) {
+                templateSelect.value = previousTemplateValue;
+            }
+        }
+    };
+    
+    typeSelect.addEventListener('change', updatePrio);
+    if (pagebuilderCheckbox) {
+        pagebuilderCheckbox.addEventListener('change', updatePagebuilderState);
+    }
+    updatePrio(); // Run once
+    updatePagebuilderState();
+}
+
+async function handleCreate(e) {
+    e.preventDefault();
+    const form = e.target;
+    const btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.textContent = 'Speichert…';
+
+    const type = form.type.value; // 'article' or 'category'
+    const isPagebuilderMode = type === 'article' && Boolean(form.pagebuilder_mode?.checked);
+
+    let templateId = form.template_id.value ? parseInt(form.template_id.value, 10) : 0;
+    if (isPagebuilderMode) {
+        try {
+            await ensureMinimalPagebuilderAssets();
+            const templates = await getTemplatesForPagebuilder();
+            const pagebuilderTemplate = templates.find(t => (t.key || '') === PAGEBUILDER_TEMPLATE_KEY);
+            if (!pagebuilderTemplate || !pagebuilderTemplate.id) {
+                throw new Error('Minimal-Pagebuilder-Template konnte nicht gefunden werden.');
+            }
+            templateId = parseInt(pagebuilderTemplate.id, 10);
+        } catch (err) {
+            alert(`Pagebuilder konnte nicht vorbereitet werden: ${err.message}`);
+            btn.disabled = false;
+            btn.textContent = 'Erstellen';
+            return;
+        }
+    }
+
+    const payload = {
+        name: form.name.value,
+        category_id: parseInt(form.parent_id.value, 10),
+        priority: parseInt(form.priority.value, 10),
+        status: parseInt(form.status.value, 10),
+        template_id: templateId,
+    };
+
+    // Correct payload keys for API
+    // structure/articles/add -> { name, category_id, priority, status, template_id }
+    // structure/categories/add -> { name, category_id, priority, status, template_id }
+
+    // API route paths are registered without trailing slash.
+    const endpoint = type === 'article' ? 'structure/articles' : 'structure/categories';
+
+    try {
+        const createResult = await apiRequest('POST', endpoint, payload);
+
+        let createdArticleId = 0;
+        if (type === 'article') {
+            createdArticleId = parseInt(
+                String(
+                    createResult?.id
+                    ?? createResult?.data?.id
+                    ?? createResult?.article?.id
+                    ?? 0
+                ),
+                10
+            ) || 0;
+        }
+
+        closeModal();
+        // Clear cache and refresh structure
+        STATE.articles = [];
+        await loadStructure();
+
+        if (isPagebuilderMode && type === 'article') {
+            if (!createdArticleId) {
+                createdArticleId = await findCreatedArticleIdFallback(form.name.value, payload.category_id, STATE.currentClang || 1);
+            }
+            if (createdArticleId) {
+                await openPagebuilderEditor(createdArticleId, STATE.currentClang || 1, true);
+            } else {
+                alert('Artikel wurde erstellt, aber konnte nicht automatisch fuer den Pagebuilder geoeffnet werden. Bitte Artikel kurz manuell oeffnen.');
+            }
+        }
+    } catch (err) {
+        alert(`Fehler beim Erstellen: ${err.message}`);
+        btn.disabled = false;
+        btn.textContent = 'Erstellen';
+    }
+}
+
+// ==================== STRUCTURE VIEW ====================
+
+// Add to STATE
+STATE.currentStructureId = 0;
+
+async function loadStructure() {
+    const container = document.getElementById('structureTree');
+    if (STATE.articles.length === 0) {
+        container.innerHTML = '<div class="loading-overlay"><span class="spinner"></span> Lade…</div>';
+        try {
+            STATE.articles = unwrapListPayload(await apiRequest('GET', 'structure/articles?per_page=1000'));
+            // Ensure clangs are loaded for the language selector
+            if (STATE.clangs.length === 0) {
+                STATE.clangs = unwrapListPayload(await apiRequest('GET', 'system/clangs'));
+            }
+        } catch (err) {
+            container.innerHTML = `<div class="empty-state"><p>Fehler: ${escHtml(err.message)}</p></div>`;
+            return;
+        }
+    }
+    populateStructureClangFilter();
+    renderStructureView(container);
+}
+
+function renderStructureView(container) {
+    if (!container) container = document.getElementById('structureTree');
+    
+    const parentId = STATE.currentStructureId || 0;
+    const currentClang = STATE.currentClang || (STATE.clangs[0] ? STATE.clangs[0].id : 1);
+
+    // Get current parent name for breadcrumb
+    let parentName = 'Root';
+    let path = [];
+    if (parentId > 0) {
+        // Find article across all valid articles, ignoring clang filter for parent lookup might be safer 
+        // but typically parents exist in the same clang.
+        let curr = STATE.articles.find(a => a.id == parentId && (!a.clang_id || a.clang_id == currentClang));
+        
+        if (curr) {
+            parentName = curr.name;
+            // Build simple path by walking up
+            let loopId = curr.parent_id;
+            let safety = 0;
+            while(loopId > 0 && safety < 20) {
+                let p = STATE.articles.find(a => a.id == loopId && (!a.clang_id || a.clang_id == currentClang));
+                if (p) {
+                    path.unshift({id: p.id, name: p.name});
+                    loopId = p.parent_id;
+                } else {
+                    break;
+                }
+                safety++;
+            }
+            path.push({id: curr.id, name: curr.name});
+        }
+    }
+
+    // Deduplicate and Filter Items
+    // Use a Map to ensure unique ID per functionality if needed, but here simple filter is enough
+    const items = STATE.articles.filter(a => {
+        if (a.clang_id && a.clang_id != currentClang) return false;
+        return (a.parent_id || 0) == parentId;
+    });
+
+    // Splits Categories and Articles
+    // Categories: startarticle = 1
+    // Articles: startarticle = 0
+    const categories = items.filter(a => a.startarticle == 1).sort((a,b) => (a.catpriority||0) - (b.catpriority||0));
+    const articles = items.filter(a => a.startarticle == 0).sort((a,b) => (a.priority||0) - (b.priority||0));
+    
+    // START ARTICLE
+    // The current category IS an article (the start article of that id). 
+    // We want to show it distinctly so the user knows they can edit the "category's content".
+    let startArticle = null;
+    if (parentId > 0) {
+        startArticle = STATE.articles.find(a => a.id == parentId && (!a.clang_id || a.clang_id == currentClang));
+    }
+
+    // Breadcrumb HTML
+    const breadcrumbHtml = `
+    <div class="structure-path" style="margin-bottom:15px; display:flex; gap:8px; align-items:center; flex-wrap:wrap; background:var(--bg-card); padding:8px 12px; border-radius:6px; border:1px solid var(--border);">
+        <button class="btn-sm" style="background:none; border:none; padding:4px 8px; cursor:pointer; color:var(--text-accent);" onclick="navigateToCategory(0)">🏠 Root</button>
+        ${path.map(p => `
+            <span style="color:var(--text-muted)">/</span>
+            <button class="btn-sm" style="background:none; border:none; padding:4px 8px; cursor:pointer;" onclick="navigateToCategory(${p.id})">${escHtml(p.name)}</button>
+        `).join('')}
+    </div>`;
+
+    const renderRow = (item, isCat, isStartArticle = false) => {
+        const icon = isStartArticle 
+            ? `<div style="color:var(--primary); display:flex; align-items:center; justify-content:center;" title="Startartikel"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 8v8M8 12h8"/></svg></div>`
+            : (isCat 
+                ? `<div style="color:var(--text-accent); display:flex; align-items:center; justify-content:center;"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/></svg></div>`
+                : `<div style="color:var(--text-muted); display:flex; align-items:center; justify-content:center;"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg></div>`);
+            
+        const action = isCat ? `navigateToCategory(${item.id})` : `showArticleDetail(${item.id})`;
+        const prio = isCat ? (item.catpriority||0) : (item.priority||0);
+        const rowClass = isStartArticle ? 'is-startarticle' : (isCat ? 'is-category' : 'is-article');
+        const rowStyle = isStartArticle ? 'background:rgba(var(--primary-rgb), 0.05); font-weight:600;' : '';
+        const statusKey = `${currentClang}:${item.id}`;
+        const pbState = isCat ? null : STATE.pagebuilderStatusCache[statusKey];
+        const pbButtonStyle = pbState === true
+            ? 'border-color:#22c55e;color:#166534;background:#dcfce7;'
+            : '';
+        const pbBadge = isCat ? '' : (pbState === true
+            ? '<span class="badge" style="margin-left:8px;background:#dcfce7;color:#166534;border:1px solid #86efac;">PB aktiv</span>'
+            : (pbState === false
+                ? '<span class="badge" style="margin-left:8px;background:var(--bg-input);color:var(--text-muted);border:1px solid var(--border);">PB aus</span>'
+                : '<span class="badge" style="margin-left:8px;background:var(--bg-input);color:var(--text-muted);border:1px solid var(--border);">PB …</span>'));
+
+        return `
+        <tr class="structure-row ${rowClass}" 
+            onclick="${action}"
+            style="cursor:pointer; border-bottom:1px solid var(--border); transition:background 0.2s; ${rowStyle}">
+            <td style="width:40px; padding:8px; text-align:center;">${icon}</td>
+            <td style="padding:8px; font-weight:500;">
+                ${escHtml(item.name)}
+                ${isStartArticle ? '<span class="badge" style="margin-left:8px; font-size:0.75em; opacity:0.8;">Startartikel</span>' : ''}
+                ${pbBadge}
+            </td>
+            <td style="width:50px; padding:8px; text-align:right; opacity:0.6; font-variant-numeric:tabular-nums;">${isStartArticle ? '–' : prio}</td>
+            <td style="width:60px; padding:8px; text-align:right; opacity:0.6; font-size:0.9em;">#${item.id}</td>
+            <td style="width:60px; padding:8px; text-align:center;">${item.status ? '<span style="color:var(--success)">●</span>' : '<span style="color:var(--text-muted)">○</span>'}</td>
+            <td style="width:170px; padding:8px; text-align:right;">
+                <div style="display:flex;gap:6px;justify-content:flex-end;">
+                    ${isCat && !isStartArticle ? `<button class="btn-icon" onclick="event.stopPropagation(); showCreateModal(${item.id})" title="Neu in ${escHtml(item.name)}" style="border:none; background:none; cursor:pointer;">➕</button>` : ''}
+                    ${!isCat ? `<button class="btn-icon" style="${pbButtonStyle}" onclick="event.stopPropagation(); openPagebuilderEditor(${item.id}, ${currentClang}, true)">Pagebuilder</button>` : ''}
+                    ${isCat ? `<button class="btn-icon" onclick="event.stopPropagation(); showCategoryMetainfo(${item.id}, ${currentClang})">Meta</button>` : `<button class="btn-icon" onclick="event.stopPropagation(); showArticleMetainfo(${item.id}, ${currentClang})">Meta</button>`}
+                    ${isCat
+                        ? `<button class="btn-icon btn-danger" onclick="event.stopPropagation(); deleteStructureCategoryRecursive(${item.id}, '${escAttr(item.name || '')}')">Löschen</button>`
+                        : `<button class="btn-icon btn-danger" onclick="event.stopPropagation(); deleteStructureArticle(${item.id}, '${escAttr(item.name || '')}')">Löschen</button>`}
+                </div>
+            </td>
+        </tr>`;
+    };
+
+    let html = breadcrumbHtml;
+    
+    // Categories Panel
+    html += `<div style="display:flex; flex-direction:column; gap:20px;">
+        <div class="panel-cats" style="background:var(--bg-card); border:1px solid var(--border); border-radius:6px; overflow:hidden;">
+            <div style="background:var(--bg-header); padding:8px 12px; border-bottom:1px solid var(--border); font-weight:600; display:flex; justify-content:space-between;">
+                <span>Kategorien</span>
+                <span class="badge" style="background:var(--bg-input); padding:2px 6px; border-radius:4px; font-size:0.8em">${categories.length}</span>
+            </div>
+            <table style="width:100%; border-collapse:collapse;">
+                ${categories.length > 0 ? categories.map(c => renderRow(c, true)).join('') : '<tr><td style="padding:15px; text-align:center; color:var(--text-muted)">Keine Kategorien</td></tr>'}
+            </table>
+        </div>
+        
+        <div class="panel-arts" style="background:var(--bg-card); border:1px solid var(--border); border-radius:6px; overflow:hidden;">
+            <div style="background:var(--bg-header); padding:8px 12px; border-bottom:1px solid var(--border); font-weight:600; display:flex; justify-content:space-between;">
+                <span>Artikel</span>
+                <span class="badge" style="background:var(--bg-input); padding:2px 6px; border-radius:4px; font-size:0.8em">${articles.length + (startArticle ? 1 : 0)}</span>
+            </div>
+            <table style="width:100%; border-collapse:collapse;">
+                ${startArticle ? renderRow(startArticle, false, true) : ''}
+                ${articles.length > 0 ? articles.map(a => renderRow(a, false)).join('') : (startArticle ? '' : '<tr><td style="padding:15px; text-align:center; color:var(--text-muted)">Keine Artikel</td></tr>')}
+            </table>
+        </div>
+    </div>
+    
+    <div style="margin-top:20px; text-align:right;">
+        <button class="btn-primary" onclick="showCreateModal(${parentId})">Neues Objekt hier erstellen</button>
+    </div>
+    `;
+
+    container.innerHTML = html;
+
+    const visibleArticles = [
+        ...(startArticle ? [startArticle] : []),
+        ...articles,
+    ];
+    refreshStructurePagebuilderStatus(visibleArticles, currentClang);
+}
+
+function getPagebuilderStatusKey(articleId, clangId) {
+    return `${Number(clangId || 1)}:${Number(articleId || 0)}`;
+}
+
+async function ensurePagebuilderModuleId() {
+    if (STATE.pagebuilderModuleId) {
+        return Number(STATE.pagebuilderModuleId);
+    }
+    const modules = await getModulesForPagebuilder();
+    const pagebuilderModule = modules.find(m => (m.key || '') === PAGEBUILDER_MODULE_KEY);
+    STATE.pagebuilderModuleId = pagebuilderModule ? Number(pagebuilderModule.id || 0) : 0;
+    return Number(STATE.pagebuilderModuleId || 0);
+}
+
+async function refreshStructurePagebuilderStatus(articleItems, clangId) {
+    const items = Array.isArray(articleItems) ? articleItems : [];
+    if (items.length === 0) return;
+
+    let moduleId = 0;
+    try {
+        moduleId = await ensurePagebuilderModuleId();
+    } catch (_) {
+        moduleId = 0;
+    }
+    if (!moduleId) {
+        return;
+    }
+
+    const missing = items
+        .map(a => Number(a.id || 0))
+        .filter(id => id > 0)
+        .filter(id => !(getPagebuilderStatusKey(id, clangId) in STATE.pagebuilderStatusCache));
+
+    if (missing.length === 0) {
+        return;
+    }
+
+    await Promise.all(missing.map(async (articleId) => {
+        try {
+            const payload = await apiRequest('GET', `structure/articles/${articleId}/slices?clang_id=${encodeURIComponent(clangId)}&per_page=200`);
+            const slices = unwrapListPayload(payload);
+            const active = slices.some(s => Number(s.module_id) === Number(moduleId));
+            STATE.pagebuilderStatusCache[getPagebuilderStatusKey(articleId, clangId)] = active;
+        } catch (_) {
+            STATE.pagebuilderStatusCache[getPagebuilderStatusKey(articleId, clangId)] = false;
+        }
+    }));
+
+    renderStructureView();
+}
+
+function navigateToCategory(id) {
+    STATE.currentStructureId = id;
+    renderStructureView();
+}
+
+function populateStructureClangFilter() {
+    const select = document.getElementById('structureClangFilter');
+    if (!select) return;
+    
+    select.innerHTML = STATE.clangs
+        .map(c => `<option value="${c.id}" ${c.id == STATE.currentClang ? 'selected' : ''}>${escHtml(c.name)}</option>`)
+        .join('');
+}
+
+function changeStructureClang(clangId) {
+    if (!clangId) return;
+    STATE.currentClang = parseInt(clangId, 10);
+    renderStructureView();
+}
+
+function getStructureDescendants(categoryId, clangId = null) {
+    const selectedClang = Number(clangId || STATE.currentClang || 1);
+
+    const scopedItems = (STATE.articles || []).filter(item => {
+        if (!item) return false;
+        if (item.clang_id && Number(item.clang_id) !== selectedClang) return false;
+        return true;
+    });
+
+    const byParent = new Map();
+    for (const item of scopedItems) {
+        const p = Number(item.parent_id || 0);
+        if (!byParent.has(p)) byParent.set(p, []);
+        byParent.get(p).push(item);
+    }
+
+    const categoryEntries = [];
+    const articleEntries = [];
+    const seenCatIds = new Set();
+    const seenArticleIds = new Set();
+
+    function walk(parentId, depth) {
+        const children = byParent.get(Number(parentId)) || [];
+        for (const child of children) {
+            const id = Number(child.id || 0);
+            if (!id) continue;
+
+            if (Number(child.startarticle || 0) === 1) {
+                if (!seenCatIds.has(id)) {
+                    seenCatIds.add(id);
+                    categoryEntries.push({ id, name: String(child.name || ''), depth });
+                    walk(id, depth + 1);
+                }
+            } else {
+                if (!seenArticleIds.has(id)) {
+                    seenArticleIds.add(id);
+                    articleEntries.push({ id, name: String(child.name || ''), depth });
+                }
+            }
+        }
+    }
+
+    walk(Number(categoryId), 1);
+
+    return {
+        categories: categoryEntries,
+        articles: articleEntries,
+    };
+}
+
+async function deleteStructureArticle(articleId, articleName = '') {
+    const label = articleName ? `„${articleName}“` : `#${articleId}`;
+    const ok = confirm(`Warnung: Artikel ${label} wird endgültig gelöscht.\n\nFortfahren?`);
+    if (!ok) return;
+
+    try {
+        await apiRequest('DELETE', `structure/articles/${articleId}`);
+        if (STATE.pagebuilderStatusCache) {
+            Object.keys(STATE.pagebuilderStatusCache).forEach(key => {
+                if (key.endsWith(`:${Number(articleId)}`)) {
+                    delete STATE.pagebuilderStatusCache[key];
+                }
+            });
+        }
+        STATE.articles = [];
+        await loadStructure();
+        closeModal();
+    } catch (err) {
+        alert(`Artikel konnte nicht gelöscht werden: ${err.message}`);
+    }
+}
+
+async function deleteStructureCategoryRecursive(categoryId, categoryName = '') {
+    const label = categoryName ? `„${categoryName}“` : `#${categoryId}`;
+    const descendants = getStructureDescendants(categoryId, STATE.currentClang || 1);
+
+    const warning = [
+        `Warnung: Kategorie ${label} wird endgültig gelöscht.`,
+        '',
+        `Es werden zusätzlich gelöscht:`,
+        `- ${descendants.categories.length} Unterkategorie(n)`,
+        `- ${descendants.articles.length} Unterartikel`,
+        '',
+        'Fortfahren?'
+    ].join('\n');
+
+    if (!confirm(warning)) {
+        return;
+    }
+
+    try {
+        // 1) Unterartikel löschen
+        for (const article of descendants.articles) {
+            await apiRequest('DELETE', `structure/articles/${article.id}`);
+        }
+
+        // 2) Unterkategorien von unten nach oben löschen
+        const nestedCategories = [...descendants.categories].sort((a, b) => b.depth - a.depth);
+        for (const cat of nestedCategories) {
+            await apiRequest('DELETE', `structure/categories/${cat.id}`);
+        }
+
+        // 3) Zielkategorie löschen
+        await apiRequest('DELETE', `structure/categories/${categoryId}`);
+
+        STATE.articles = [];
+        await loadStructure();
+        closeModal();
+    } catch (err) {
+        alert(`Kategorie konnte nicht vollständig gelöscht werden: ${err.message}`);
+    }
+}
+
+// ==================== MEDIA ====================
+
+let allMediaLoaded = [];
+
+async function loadMedia() {
+    const container = document.getElementById('mediaGallery');
+    container.innerHTML = '<div class="loading-overlay"><span class="spinner"></span> Lade Medien…</div>';
+
+    try {
+        await ensureMediaCategoriesLoaded();
+        populateMediaCategoryFilter();
+        if (STATE.media.length === 0) {
+            STATE.media = unwrapListPayload(await apiRequest('GET', 'media?per_page=500'));
+        }
+        allMediaLoaded = [...STATE.media];
+        filterMedia();
+    } catch (err) {
+        container.innerHTML = `<div class="empty-state"><p>Fehler: ${escHtml(err.message)}</p></div>`;
+    }
+}
+
+function filterMedia() {
+    const categoryFilter = document.getElementById('mediaCategoryFilter').value;
+    const typeFilter = document.getElementById('mediaTypeFilter').value;
+    const sortFilter = (document.getElementById('mediaSortFilter')?.value || 'newest');
+    const search = document.getElementById('mediaSearchInput').value.toLowerCase();
+
+    let filtered = allMediaLoaded;
+    if (categoryFilter !== '') {
+        filtered = filtered.filter(m => String(m.category_id || 0) === String(categoryFilter));
+    }
+    if (typeFilter) {
+        filtered = filtered.filter(m => (m.filetype || '').includes(typeFilter));
+    }
+    if (search) {
+        filtered = filtered.filter(m =>
+            (m.filename || '').toLowerCase().includes(search) ||
+            (m.title || '').toLowerCase().includes(search)
+        );
+    }
+
+    filtered = [...filtered].sort((a, b) => {
+        if (sortFilter === 'az') {
+            return String(a.filename || '').localeCompare(String(b.filename || ''), 'de', { sensitivity: 'base' });
+        }
+        if (sortFilter === 'za') {
+            return String(b.filename || '').localeCompare(String(a.filename || ''), 'de', { sensitivity: 'base' });
+        }
+
+        const aTime = new Date(a.updatedate || a.createdate || 0).getTime();
+        const bTime = new Date(b.updatedate || b.createdate || 0).getTime();
+        if (sortFilter === 'oldest') {
+            return aTime - bTime;
+        }
+        return bTime - aTime;
+    });
+
+    renderMediaGrid(filtered);
+}
+
+function renderMediaGrid(items) {
+    const container = document.getElementById('mediaGallery');
+    if (items.length === 0) {
+        container.innerHTML = '<div class="empty-state"><p>Keine Medien gefunden</p></div>';
+        return;
+    }
+
+    container.innerHTML = `<div class="media-grid">${items.map(m => {
+        const isImage = (m.filetype || '').startsWith('image/');
+        const thumbHtml = isImage
+            ? `<img src="${CONFIG.url}/media/${escAttr(m.filename)}" alt="${escAttr(m.filename)}" loading="lazy" onerror="this.outerHTML='<div class=\\'file-icon\\'>🖼</div>'">`
+            : `<div class="file-icon">${fileEmoji(m.filetype)}</div>`;
+
+        return `<div class="media-item" onclick="showMediaDetail('${escAttr(m.filename)}')">
+            <div class="media-thumb">${thumbHtml}</div>
+            <div class="media-info">
+                <div class="filename" title="${escAttr(m.filename)}">${escHtml(m.filename)}</div>
+                <div class="filedetails">${formatSize(m.filesize)} · ${shortType(m.filetype)}</div>
+            </div>
+        </div>`;
+    }).join('')}</div>`;
+}
+
+async function showMediaDetail(filename) {
+    try {
+        const info = await apiRequest('GET', `media/${encodeURIComponent(filename)}/info`);
+        const isImage = (info.filetype || '').startsWith('image/');
+        const isVideo = (info.filetype || '').startsWith('video/');
+        const isAudio = (info.filetype || '').startsWith('audio/');
+        const mediaUrl = `${CONFIG.url}/media/${encodeURIComponent(filename)}`;
+
+        let html = '';
+        if (isImage) {
+            html += `<div style="text-align:center;margin-bottom:16px;background:var(--bg-input);border-radius:8px;padding:12px;">
+                <img src="${mediaUrl}" style="max-width:100%;max-height:300px;border-radius:6px;" alt="">
+            </div>`;
+        } else if (isVideo) {
+            html += `<div style="text-align:center;margin-bottom:16px;background:var(--bg-input);border-radius:8px;padding:12px;">
+                <video controls preload="metadata" style="width:100%;max-height:360px;border-radius:6px;background:#000;" src="${mediaUrl}">
+                    Dein Browser kann dieses Video nicht abspielen.
+                </video>
+            </div>`;
+        } else if (isAudio) {
+            html += `<div style="margin-bottom:16px;background:var(--bg-input);border-radius:8px;padding:12px;">
+                <audio controls preload="metadata" style="width:100%;" src="${mediaUrl}">
+                    Dein Browser kann diese Audiodatei nicht abspielen.
+                </audio>
+            </div>`;
+        }
+
+        const rows = [
+            ['Dateiname', info.filename],
+            ['Original', info.originalname],
+            ['Typ', info.filetype],
+            ['Größe', formatSize(info.filesize)],
+            ['Kategorie', info.category_id || 0],
+            ['Titel', info.title || '–'],
+        ];
+        if (info.width) rows.push(['Abmessungen', `${info.width} × ${info.height} px`]);
+        rows.push(
+            ['Erstellt', `${formatDate(info.createdate)} von ${info.createuser}`],
+            ['Aktualisiert', `${formatDate(info.updatedate)} von ${info.updateuser}`],
+            ['Datei existiert', info.file_exists ? '✅ Ja' : '❌ Nein'],
+            ['In Verwendung', info.is_in_use ? '✅ Ja' : '❌ Nein'],
+        );
+
+        html += rows.map(([l, v]) => `<div class="detail-row"><span class="detail-label">${l}</span><span class="detail-value">${escHtml(String(v || '–'))}</span></div>`).join('');
+
+        html += `<div style="margin-top:16px;display:flex;gap:8px;flex-wrap:wrap;">
+            <button class="btn-icon" onclick="showMediaMetaEditor('${escAttr(filename)}')">
+                Meta bearbeiten
+            </button>
+            <button class="btn-icon" onclick="showMediaMetainfoValues('${escAttr(filename)}')">
+                Metainfo-Werte
+            </button>
+            <button class="btn-icon btn-danger" onclick="deleteMedia('${escAttr(filename)}')">
+                Datei löschen
+            </button>
+            <a href="${CONFIG.url}/api/media/${encodeURIComponent(filename)}/file" target="_blank" class="btn-icon" style="text-decoration:none;display:inline-flex;">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                Datei herunterladen
+            </a>
+        </div>`;
+
+        showModal(filename, html);
+    } catch (err) {
+        showModal('Fehler', `<p>${escHtml(err.message)}</p>`);
+    }
+}
+
+// ==================== TEMPLATES ====================
+
+async function loadTemplates() {
+    const container = document.getElementById('templatesTable');
+    try {
+        if (STATE.templates.length === 0) {
+            STATE.templates = unwrapListPayload(await apiRequest('GET', 'templates?per_page=1000'));
+        }
+        renderTemplates();
+    } catch (err) {
+        container.innerHTML = `<div class="empty-state"><p>Fehler: ${escHtml(err.message)}</p></div>`;
+    }
+}
+
+function renderTemplates() {
+    const container = document.getElementById('templatesTable');
+    if (STATE.templates.length === 0) {
+        container.innerHTML = '<div class="empty-state"><p>Keine Templates vorhanden</p></div>';
+        return;
+    }
+
+    container.innerHTML = `<table class="data-table">
+        <thead><tr><th>ID</th><th>Name</th><th>Key</th><th>Status</th><th>Aktualisiert</th><th>Aktion</th></tr></thead>
+        <tbody>${STATE.templates.map(t => `
+            <tr>
+                <td class="id-col">${t.id}</td>
+                <td onclick="showTemplateDetail(${t.id})" style="cursor:pointer">${escHtml(t.name)}</td>
+                <td><code>${escHtml(t.key || '–')}</code></td>
+                <td>${t.active ? '<span class="pill online">Aktiv</span>' : '<span class="pill offline">Inaktiv</span>'}</td>
+                <td class="date-col">${formatDate(t.updatedate)}</td>
+                <td>
+                    <div style="display:flex;gap:6px;">
+                        <button class="btn-icon" onclick="showTemplateEditor(${t.id})">Bearbeiten</button>
+                        <button class="btn-icon btn-danger" onclick="deleteTemplate(${t.id}, '${escAttr(t.name || '')}')">Löschen</button>
+                    </div>
+                </td>
+            </tr>
+        `).join('')}</tbody>
+    </table>`;
+}
+
+function showTemplateDetail(id) {
+    const t = STATE.templates.find(t => t.id === id);
+    if (!t) return;
+
+    // Helper: render restriction badge
+    function restrictionBadge(restrictions) {
+        if (!restrictions) return '<span class="pill offline">–</span>';
+        if (restrictions.categories?.all) {
+            return '<span class="pill online">Alle Kategorien erlaubt</span>';
+        }
+        const ids = restrictions.categories?.category_ids || [];
+        return ids.length
+            ? `<span class="pill" style="background:var(--bg);border:1px solid var(--border)">Nur Kat. ${ids.join(', ')}</span>`
+            : '<span class="pill offline">Keine Kategorie erlaubt</span>';
+    }
+
+    function moduleBadge(restrictions) {
+        if (!restrictions?.modules) return '<span class="pill offline">–</span>';
+        const parts = [];
+        for (const [ctype, info] of Object.entries(restrictions.modules)) {
+            if (info.all) {
+                parts.push(`CType ${ctype}: alle Module`);
+            } else {
+                const ids = info.module_ids || [];
+                parts.push(`CType ${ctype}: ${ids.length ? 'Modul ' + ids.join(', ') : 'kein Modul'}`);
+            }
+        }
+        return parts.length
+            ? parts.map(p => `<span class="pill" style="background:var(--bg);border:1px solid var(--border)">${escHtml(p)}</span>`).join(' ')
+            : '<span class="pill offline">–</span>';
+    }
+
+    let html = `<div class="detail-row"><span class="detail-label">ID</span><span class="detail-value">${t.id}</span></div>
+        <div class="detail-row"><span class="detail-label">Name</span><span class="detail-value">${escHtml(t.name)}</span></div>
+        <div class="detail-row"><span class="detail-label">Key</span><span class="detail-value">${escHtml(t.key || '–')}</span></div>
+        <div class="detail-row"><span class="detail-label">Aktiv</span><span class="detail-value">${t.active ? 'Ja' : 'Nein'}</span></div>
+        <div class="detail-row"><span class="detail-label">Erstellt</span><span class="detail-value">${formatDate(t.createdate)} von ${escHtml(t.createuser || '–')}</span></div>
+        <div class="detail-row"><span class="detail-label">Aktualisiert</span><span class="detail-value">${formatDate(t.updatedate)} von ${escHtml(t.updateuser || '–')}</span></div>`;
+
+    // Category / Module restrictions
+    if (t.restrictions) {
+        html += `<div class="detail-row" style="border-top:1px solid var(--border);margin-top:12px;padding-top:12px;">
+            <span class="detail-label">Kategorien</span>
+            <span class="detail-value">${restrictionBadge(t.restrictions)}</span>
+        </div>
+        <div class="detail-row">
+            <span class="detail-label">Module</span>
+            <span class="detail-value" style="flex-wrap:wrap;display:flex;gap:4px;">${moduleBadge(t.restrictions)}</span>
+        </div>`;
+    }
+
+    if (t.content) {
+        html += `<div style="margin-top:16px"><strong>Template-Code:</strong></div>
+            <div class="code-block" style="margin-top:8px">${escHtml(t.content)}</div>`;
+    }
+
+    html += `<div style="margin-top:16px;display:flex;gap:8px;flex-wrap:wrap;">
+        <button class="btn-icon" onclick="showTemplateEditor(${t.id})">Template bearbeiten</button>
+        <button class="btn-icon" onclick="showTemplateAttributesEditor(${t.id})">Einschränkungen</button>
+        <button class="btn-icon btn-danger" onclick="deleteTemplate(${t.id}, '${escAttr(t.name || '')}')">Template löschen</button>
+    </div>`;
+
+    showModal(`Template: ${t.name}`, html);
+}
+
+async function showTemplateAttributesEditor(id) {
+    const t = STATE.templates.find(t => t.id === id);
+    if (!t) return;
+
+    // Ensure categories and modules are loaded
+    if (!STATE.categories || STATE.categories.length === 0) {
+        try {
+            STATE.categories = unwrapListPayload(await apiRequest('GET', 'structure/articles?per_page=1000'));
+        } catch (e) { STATE.categories = []; }
+    }
+    const allModules = STATE.modules.length ? STATE.modules : unwrapListPayload(await apiRequest('GET', 'modules?per_page=1000'));
+
+    const restr = t.restrictions || { categories: { all: true, category_ids: [] }, modules: { '1': { all: true, module_ids: [] } } };
+
+    // Collect unique top-level categories from articles (parent_id=0)
+    const cats = [...new Map(
+        STATE.articles
+            .filter(a => (a.parent_id ?? 0) == 0 || a.type == 'category')
+            .map(a => [a.id, a])
+    ).values()].slice(0, 60); // cap for usability
+
+    const catAllChecked = restr.categories?.all ? 'checked' : '';
+    const catIds        = restr.categories?.category_ids || [];
+
+    const catCheckboxes = cats.map(c => {
+        const checked = (!restr.categories?.all && catIds.includes(c.id)) ? 'checked' : '';
+        return `<label style="display:flex;align-items:center;gap:6px;padding:3px 0;">
+            <input type="checkbox" class="cb-cat" value="${c.id}" ${checked}> ${escHtml(c.name)} <small style="color:var(--text-muted)">(#${c.id})</small>
+        </label>`;
+    }).join('');
+
+    // Modules for ctype 1
+    const ctype1  = restr.modules?.['1'] || { all: true, module_ids: [] };
+    const modAllChecked = ctype1.all ? 'checked' : '';
+    const modIds  = ctype1.module_ids || [];
+
+    const modCheckboxes = allModules.map(m => {
+        const checked = (!ctype1.all && modIds.includes(m.id)) ? 'checked' : '';
+        return `<label style="display:flex;align-items:center;gap:6px;padding:3px 0;">
+            <input type="checkbox" class="cb-mod" value="${m.id}" ${checked}> ${escHtml(m.name)} <small style="color:var(--text-muted)">(#${m.id})</small>
+        </label>`;
+    }).join('');
+
+    const html = `
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:24px;">
+        <div>
+            <h4 style="margin:0 0 10px;font-size:14px;">Kategorien</h4>
+            <label style="display:flex;align-items:center;gap:8px;padding:4px 0;font-weight:600;">
+                <input type="checkbox" id="catAll" ${catAllChecked} onchange="toggleAttrAll('catAll','.cb-cat')">
+                Alle Kategorien erlaubt
+            </label>
+            <div id="catList" style="margin-top:8px;max-height:260px;overflow-y:auto;padding-right:4px;${restr.categories?.all ? 'opacity:.4;pointer-events:none' : ''}">
+                ${catCheckboxes || '<p style="color:var(--text-muted);font-size:13px">Keine Kategorien gefunden</p>'}
+            </div>
+        </div>
+        <div>
+            <h4 style="margin:0 0 10px;font-size:14px;">Module (CType 1)</h4>
+            <label style="display:flex;align-items:center;gap:8px;padding:4px 0;font-weight:600;">
+                <input type="checkbox" id="modAll" ${modAllChecked} onchange="toggleAttrAll('modAll','.cb-mod')">
+                Alle Module erlaubt
+            </label>
+            <div id="modList" style="margin-top:8px;max-height:260px;overflow-y:auto;padding-right:4px;${ctype1.all ? 'opacity:.4;pointer-events:none' : ''}">
+                ${modCheckboxes || '<p style="color:var(--text-muted);font-size:13px">Keine Module vorhanden</p>'}
+            </div>
+        </div>
+    </div>
+    <div style="margin-top:20px;display:flex;gap:10px;justify-content:flex-end;">
+        <button class="btn btn-secondary" onclick="closeModal()">Abbrechen</button>
+        <button class="btn btn-primary" onclick="saveTemplateAttributes(${id})">Speichern</button>
+    </div>`;
+
+    showModal(`Einschränkungen: ${t.name}`, html);
+}
+
+function toggleAttrAll(checkboxId, groupSelector) {
+    const all  = document.getElementById(checkboxId).checked;
+    const list = document.querySelector(checkboxId === 'catAll' ? '#catList' : '#modList');
+    if (list) {
+        list.style.opacity         = all ? '.4' : '1';
+        list.style.pointerEvents   = all ? 'none' : '';
+    }
+}
+
+async function saveTemplateAttributes(id) {
+    const catAll  = document.getElementById('catAll')?.checked ?? true;
+    const modAll  = document.getElementById('modAll')?.checked ?? true;
+
+    const catIds = catAll ? [] : [...document.querySelectorAll('.cb-cat:checked')].map(cb => parseInt(cb.value));
+    const modIds = modAll ? [] : [...document.querySelectorAll('.cb-mod:checked')].map(cb => parseInt(cb.value));
+
+    const payload = {
+        categories: { all: catAll, ids: catIds },
+        modules:    { '1': { all: modAll, ids: modIds } },
+    };
+
+    try {
+        await apiRequest('PATCH', `templates/${id}/attributes`, payload);
+        // Refresh template in STATE
+        const fresh = await apiRequest('GET', `templates/${id}`);
+        const idx   = STATE.templates.findIndex(t => t.id === id);
+        if (idx !== -1 && fresh) STATE.templates[idx] = fresh;
+        closeModal();
+        showToast('Einschränkungen gespeichert');
+        renderTemplates();
+    } catch (err) {
+        alert('Fehler: ' + err.message);
+    }
+}
+
+// ==================== MODULES ====================
+
+async function loadModules() {
+    const container = document.getElementById('modulesTable');
+    try {
+        if (STATE.modules.length === 0) {
+            STATE.modules = unwrapListPayload(await apiRequest('GET', 'modules?per_page=1000'));
+        }
+        renderModules();
+    } catch (err) {
+        container.innerHTML = `<div class="empty-state"><p>Fehler: ${escHtml(err.message)}</p></div>`;
+    }
+}
+
+function renderModules() {
+    const container = document.getElementById('modulesTable');
+    if (STATE.modules.length === 0) {
+        container.innerHTML = '<div class="empty-state"><p>Keine Module vorhanden</p></div>';
+        return;
+    }
+
+    container.innerHTML = `<table class="data-table">
+        <thead><tr><th>ID</th><th>Name</th><th>Key</th><th>Aktualisiert</th><th>Aktion</th></tr></thead>
+        <tbody>${STATE.modules.map(m => `
+            <tr>
+                <td class="id-col">${m.id}</td>
+                <td onclick="showModuleDetail(${m.id})" style="cursor:pointer">${escHtml(m.name)}</td>
+                <td><code>${escHtml(m.key || '–')}</code></td>
+                <td class="date-col">${formatDate(m.updatedate)}</td>
+                <td>
+                    <div style="display:flex;gap:6px;">
+                        <button class="btn-icon" onclick="showModuleEditor(${m.id})">Bearbeiten</button>
+                        <button class="btn-icon btn-danger" onclick="deleteModule(${m.id}, '${escAttr(m.name || '')}')">Löschen</button>
+                    </div>
+                </td>
+            </tr>
+        `).join('')}</tbody>
+    </table>`;
+}
+
+function showModuleDetail(id) {
+    const m = STATE.modules.find(m => m.id === id);
+    if (!m) return;
+
+    let html = `<div class="detail-row"><span class="detail-label">ID</span><span class="detail-value">${m.id}</span></div>
+        <div class="detail-row"><span class="detail-label">Name</span><span class="detail-value">${escHtml(m.name)}</span></div>
+        <div class="detail-row"><span class="detail-label">Key</span><span class="detail-value">${escHtml(m.key || '–')}</span></div>
+        <div class="detail-row"><span class="detail-label">Erstellt</span><span class="detail-value">${formatDate(m.createdate)} von ${escHtml(m.createuser || '–')}</span></div>
+        <div class="detail-row"><span class="detail-label">Aktualisiert</span><span class="detail-value">${formatDate(m.updatedate)} von ${escHtml(m.updateuser || '–')}</span></div>`;
+
+    if (m.input) {
+        html += `<div style="margin-top:16px"><strong>Eingabe:</strong></div>
+            <div class="code-block" style="margin-top:8px">${escHtml(m.input)}</div>`;
+    }
+    if (m.output) {
+        html += `<div style="margin-top:16px"><strong>Ausgabe:</strong></div>
+            <div class="code-block" style="margin-top:8px">${escHtml(m.output)}</div>`;
+    }
+
+    html += `<div style="margin-top:16px;display:flex;gap:8px;flex-wrap:wrap;">
+        <button class="btn-icon" onclick="showModuleEditor(${m.id})">Modul bearbeiten</button>
+        <button class="btn-icon btn-danger" onclick="deleteModule(${m.id}, '${escAttr(m.name || '')}')">Modul löschen</button>
+    </div>`;
+
+    showModal(`Modul: ${m.name}`, html);
+}
+
+// ==================== USERS ====================
+
+async function loadUsers() {
+    const container = document.getElementById('usersTable');
+
+    try {
+        const [users, roles] = await Promise.all([
+            apiRequest('GET', 'users'),
+            apiRequest('GET', 'users/roles'),
+        ]);
+        STATE.users = unwrapListPayload(users);
+        STATE.roles = unwrapListPayload(roles);
+        renderUsers();
+        renderRoles();
+    } catch (err) {
+        container.innerHTML = `<div class="empty-state"><p>Fehler: ${escHtml(err.message)}</p></div>`;
+    }
+}
+
+function renderUsers() {
+    const container = document.getElementById('usersTable');
+    if (STATE.users.length === 0) {
+        container.innerHTML = '<div class="empty-state"><p>Keine Benutzer gefunden</p></div>';
+        return;
+    }
+
+    container.innerHTML = `<table class="data-table">
+        <thead><tr><th>ID</th><th>Login</th><th>Name</th><th>E-Mail</th><th>Rolle</th><th>Status</th><th>Letzter Login</th><th>Aktion</th></tr></thead>
+        <tbody>${STATE.users.map(u => `
+            <tr>
+                <td class="id-col">${u.id}</td>
+                <td><strong>${escHtml(u.login)}</strong></td>
+                <td>${escHtml(u.name || '–')}</td>
+                <td>${escHtml(u.email || '–')}</td>
+                <td>${u.admin ? '<span class="pill admin">Admin</span>' : '<span class="pill offline">User</span>'}</td>
+                <td>${u.status ? '<span class="pill online">Aktiv</span>' : '<span class="pill offline">Inaktiv</span>'}</td>
+                <td class="date-col">${formatDate(u.lastlogin)}</td>
+                <td>
+                    <div style="display:flex;gap:6px;">
+                        <button class="btn-icon" onclick="showUserEditor(${u.id})">Bearbeiten</button>
+                        <button class="btn-icon" onclick="showUserRoleManager(${u.id})">Rollen</button>
+                        <button class="btn-icon btn-danger" onclick="deleteUser(${u.id}, '${escAttr(u.login || '')}')">Löschen</button>
+                    </div>
+                </td>
+            </tr>
+        `).join('')}</tbody>
+    </table>`;
+}
+
+function renderRoles() {
+    const container = document.getElementById('rolesTable');
+    if (STATE.roles.length === 0) {
+        container.innerHTML = '<div class="empty-state"><p>Keine Rollen definiert</p></div>';
+        return;
+    }
+
+    container.innerHTML = `<table class="data-table">
+        <thead><tr><th>ID</th><th>Name</th><th>Beschreibung</th><th>Aktualisiert</th><th>Aktion</th></tr></thead>
+        <tbody>${STATE.roles.map(r => `
+            <tr>
+                <td class="id-col">${r.id}</td>
+                <td><strong>${escHtml(r.name)}</strong></td>
+                <td class="truncate">${escHtml(r.description || '–')}</td>
+                <td class="date-col">${formatDate(r.updatedate)}</td>
+                <td>
+                    <div style="display:flex;gap:6px;">
+                        <button class="btn-icon" onclick="showRoleEditor(${r.id})">Bearbeiten</button>
+                        <button class="btn-icon" onclick="duplicateRole(${r.id}, '${escAttr(r.name || '')}')">Duplizieren</button>
+                        <button class="btn-icon btn-danger" onclick="deleteRole(${r.id}, '${escAttr(r.name || '')}')">Löschen</button>
+                    </div>
+                </td>
+            </tr>
+        `).join('')}</tbody>
+    </table>`;
+}
+
+async function showRoleEditor(id = null) {
+    try {
+        let role = null;
+        if (id) {
+            role = await apiRequest('GET', `users/roles/${id}`);
+        }
+
+        const perms = Array.isArray(role?.perms)
+            ? role.perms.join(', ')
+            : (typeof role?.perms === 'string' ? role.perms : '');
+
+        const html = `<form onsubmit="submitRoleForm(event, ${id || 'null'})">
+            <div class="form-group">
+                <label>Name</label>
+                <input type="text" name="name" required value="${escAttr(role?.name || '')}">
+            </div>
+            <div class="form-group">
+                <label>Beschreibung</label>
+                <textarea name="description" style="width:100%;min-height:100px;padding:12px;border-radius:var(--radius-sm);border:1px solid var(--border);background:var(--bg-input);color:var(--text);">${escHtml(role?.description || '')}</textarea>
+            </div>
+            <div class="form-group">
+                <label>Rechte (Komma-getrennt)</label>
+                <input type="text" name="perms" value="${escAttr(perms)}" placeholder="z. B. structure, media, user[]">
+            </div>
+            <div style="display:flex; gap:12px; margin-top:24px;">
+                <button type="button" class="btn-primary" style="background:var(--bg-input); color:var(--text); border:1px solid var(--border);" onclick="closeModal()">Abbrechen</button>
+                <button type="submit" class="btn-primary">${id ? 'Speichern' : 'Anlegen'}</button>
+            </div>
+        </form>`;
+
+        showModal(id ? `Rolle bearbeiten #${id}` : 'Neue Rolle', html);
+    } catch (err) {
+        showModal('Fehler', `<p>${escHtml(err.message)}</p>`);
+    }
+}
+
+function parsePermList(value) {
+    return String(value || '')
+        .split(',')
+        .map(v => v.trim())
+        .filter(v => v.length > 0);
+}
+
+async function submitRoleForm(e, id) {
+    e.preventDefault();
+    const form = e.target;
+    const btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.textContent = 'Speichert…';
+
+    const payload = {
+        name: form.name.value,
+        description: form.description.value,
+        perms: parsePermList(form.perms.value),
+    };
+
+    try {
+        if (id) {
+            await apiRequest('PATCH', `users/roles/${id}`, payload);
+        } else {
+            await apiRequest('POST', 'users/roles', payload);
+        }
+        await loadUsers();
+        closeModal();
+    } catch (err) {
+        alert(`Rolle konnte nicht gespeichert werden: ${err.message}`);
+        btn.disabled = false;
+        btn.textContent = id ? 'Speichern' : 'Anlegen';
+    }
+}
+
+async function duplicateRole(id, name) {
+    const newName = prompt('Name der neuen Rolle:', `${name || ('Rolle #' + id)} Kopie`);
+    if (!newName) return;
+    try {
+        await apiRequest('POST', `users/roles/${id}/duplicate`, { name: newName });
+        await loadUsers();
+    } catch (err) {
+        alert(`Rolle konnte nicht dupliziert werden: ${err.message}`);
+    }
+}
+
+async function deleteRole(id, name) {
+    if (!confirm(`Rolle wirklich löschen?\n\n${name || ('#' + id)}`)) return;
+    try {
+        await apiRequest('DELETE', `users/roles/${id}`);
+        await loadUsers();
+    } catch (err) {
+        alert(`Rolle konnte nicht gelöscht werden: ${err.message}`);
+    }
+}
+
+function showUserEditor(id = null) {
+    const u = id ? STATE.users.find(item => item.id === id) : null;
+    const html = `<form onsubmit="submitUserForm(event, ${id || 'null'})">
+        <div class="form-group"><label>Name</label><input type="text" name="name" required value="${escAttr(u?.name || '')}"></div>
+        <div class="form-group"><label>Login</label><input type="text" name="login" required value="${escAttr(u?.login || '')}"></div>
+        ${id ? '' : `<div class="form-group"><label>Passwort</label><input type="password" name="password" required></div>`}
+        <div class="form-group"><label>E-Mail</label><input type="email" name="email" value="${escAttr(u?.email || '')}" ${id ? 'disabled' : ''}></div>
+        <div class="form-group"><label>Sprache</label><input type="text" name="language" value="${escAttr(u?.language || 'de_de')}"></div>
+        <div class="form-group"><label>Startseite</label><input type="text" name="startpage" value="${escAttr(u?.startpage || 'structure')}"></div>
+        <div class="form-group"><label>Status</label>
+            <select name="status">
+                <option value="1" ${(u?.status ?? 1) ? 'selected' : ''}>Aktiv</option>
+                <option value="0" ${(u && !u.status) ? 'selected' : ''}>Inaktiv</option>
+            </select>
+        </div>
+        ${id ? '' : `<div class="form-group"><label>Admin</label>
+            <select name="admin"><option value="0" selected>Nein</option><option value="1">Ja</option></select>
+        </div>`}
+        <div style="display:flex; gap:12px; margin-top:24px;">
+            <button type="button" class="btn-primary" style="background:var(--bg-input); color:var(--text); border:1px solid var(--border);" onclick="closeModal()">Abbrechen</button>
+            <button type="submit" class="btn-primary">${id ? 'Speichern' : 'Anlegen'}</button>
+        </div>
+    </form>`;
+    showModal(id ? `Benutzer bearbeiten #${id}` : 'Neuer Benutzer', html);
+}
+
+async function submitUserForm(e, id) {
+    e.preventDefault();
+    const form = e.target;
+    const btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.textContent = 'Speichert…';
+
+    try {
+        if (id) {
+            await apiRequest('PATCH', `users/${id}`, {
+                name: form.name.value,
+                login: form.login.value,
+                status: parseInt(form.status.value, 10),
+                language: form.language.value,
+                startpage: form.startpage.value,
+            });
+        } else {
+            await apiRequest('POST', 'users', {
+                name: form.name.value,
+                login: form.login.value,
+                password: form.password.value,
+                email: form.email.value,
+                status: parseInt(form.status.value, 10),
+                admin: parseInt(form.admin.value, 10),
+                language: form.language.value,
+                startpage: form.startpage.value,
+            });
+        }
+        await loadUsers();
+        closeModal();
+    } catch (err) {
+        alert(`Benutzer konnte nicht gespeichert werden: ${err.message}`);
+        btn.disabled = false;
+        btn.textContent = id ? 'Speichern' : 'Anlegen';
+    }
+}
+
+async function deleteUser(id, login) {
+    if (!confirm(`Benutzer wirklich löschen?\n\n${login || ('#' + id)}`)) return;
+    try {
+        await apiRequest('DELETE', `users/${id}`);
+        await loadUsers();
+    } catch (err) {
+        alert(`Benutzer konnte nicht gelöscht werden: ${err.message}`);
+    }
+}
+
+async function showUserRoleManager(userId) {
+    try {
+        if (STATE.roles.length === 0) {
+            STATE.roles = unwrapListPayload(await apiRequest('GET', 'users/roles'));
+        }
+        const assigned = unwrapListPayload(await apiRequest('GET', `users/${userId}/role`));
+        const assignedIds = new Set(assigned.map(r => Number(r.id)));
+
+        const listHtml = STATE.roles.map(r => {
+            const hasRole = assignedIds.has(Number(r.id));
+            return `<tr>
+                <td class="id-col">${r.id}</td>
+                <td>${escHtml(r.name)}</td>
+                <td>${escHtml(r.description || '–')}</td>
+                <td>
+                    <button class="btn-icon ${hasRole ? 'btn-danger' : ''}" onclick="toggleUserRole(${userId}, ${r.id}, ${hasRole ? 'true' : 'false'})">
+                        ${hasRole ? 'Entfernen' : 'Zuweisen'}
+                    </button>
+                </td>
+            </tr>`;
+        }).join('');
+
+        showModal(`Rollen für Benutzer #${userId}`, `<table class="data-table"><thead><tr><th>ID</th><th>Name</th><th>Beschreibung</th><th>Aktion</th></tr></thead><tbody>${listHtml}</tbody></table>`);
+    } catch (err) {
+        showModal('Fehler', `<p>${escHtml(err.message)}</p>`);
+    }
+}
+
+async function toggleUserRole(userId, roleId, hasRole) {
+    try {
+        if (hasRole) {
+            await apiRequest('DELETE', `users/${userId}/role/${roleId}`);
+        } else {
+            await apiRequest('POST', `users/${userId}/role/${roleId}`);
+        }
+        await showUserRoleManager(userId);
+    } catch (err) {
+        alert(`Rollenänderung fehlgeschlagen: ${err.message}`);
+    }
+}
+
+// ==================== CLANGS ====================
+
+async function loadClangs() {
+    const container = document.getElementById('clangsTable');
+    try {
+        STATE.clangs = unwrapListPayload(await apiRequest('GET', 'system/clangs'));
+        renderClangs();
+    } catch (err) {
+        container.innerHTML = `<div class="empty-state"><p>Fehler: ${escHtml(err.message)}</p></div>`;
+    }
+}
+
+async function ensureMediaCategoriesLoaded() {
+    if (STATE.mediaCategories.length > 0) return;
+    STATE.mediaCategories = unwrapListPayload(await apiRequest('GET', 'media/category?per_page=1000'));
+}
+
+function populateMediaCategoryFilter() {
+    const select = document.getElementById('mediaCategoryFilter');
+    if (!select) return;
+    const current = select.value;
+    select.innerHTML = `<option value="">Alle Kategorien</option>${STATE.mediaCategories
+        .map(c => `<option value="${c.id}">${escHtml(c.name)} (#${c.id})</option>`)
+        .join('')}`;
+    if ([...select.options].some(o => o.value === current)) {
+        select.value = current;
+    }
+}
+
+async function showMediaCategoryManager() {
+    try {
+        await ensureMediaCategoriesLoaded();
+
+        const rows = STATE.mediaCategories.map(c => `
+            <tr>
+                <td class="id-col">${c.id}</td>
+                <td>${escHtml(c.name)}</td>
+                <td>${c.parent_id || 0}</td>
+                <td>
+                    <div style="display:flex;gap:6px;">
+                        <button class="btn-icon" onclick="renameMediaCategory(${c.id}, '${escAttr(c.name)}')">Umbenennen</button>
+                        <button class="btn-icon btn-danger" onclick="deleteMediaCategory(${c.id}, '${escAttr(c.name)}')">Löschen</button>
+                    </div>
+                </td>
+            </tr>
+        `).join('');
+
+        const html = `<form onsubmit="submitMediaCategoryCreate(event)">
+            <div style="display:grid;grid-template-columns:1fr 140px 120px;gap:8px;align-items:end;">
+                <div class="form-group" style="margin:0;">
+                    <label>Neue Kategorie</label>
+                    <input type="text" name="name" required placeholder="Name">
+                </div>
+                <div class="form-group" style="margin:0;">
+                    <label>Parent ID</label>
+                    <input type="number" name="parent_id" min="0" value="0">
+                </div>
+                <button class="btn-primary" type="submit" style="height:42px;">Anlegen</button>
+            </div>
+        </form>
+        <div style="margin-top:16px;">
+            <table class="data-table">
+                <thead><tr><th>ID</th><th>Name</th><th>Parent</th><th>Aktion</th></tr></thead>
+                <tbody>${rows || '<tr><td colspan="4" style="padding:16px;">Keine Kategorien vorhanden.</td></tr>'}</tbody>
+            </table>
+        </div>`;
+
+        showModal('Medien-Kategorien verwalten', html);
+    } catch (err) {
+        showModal('Fehler', `<p>${escHtml(err.message)}</p>`);
+    }
+}
+
+async function submitMediaCategoryCreate(e) {
+    e.preventDefault();
+    const form = e.target;
+    const payload = {
+        name: form.name.value,
+        parent_id: parseInt(form.parent_id.value || '0', 10),
+    };
+
+    try {
+        await apiRequest('POST', 'media/category', payload);
+        STATE.mediaCategories = [];
+        await ensureMediaCategoriesLoaded();
+        populateMediaCategoryFilter();
+        await showMediaCategoryManager();
+    } catch (err) {
+        alert(`Kategorie konnte nicht angelegt werden: ${err.message}`);
+    }
+}
+
+async function renameMediaCategory(id, oldName) {
+    const newName = prompt('Neuer Name der Kategorie:', oldName || '');
+    if (!newName || newName === oldName) return;
+    try {
+        await apiRequest('PATCH', `media/category/${id}`, { name: newName });
+        STATE.mediaCategories = [];
+        await ensureMediaCategoriesLoaded();
+        populateMediaCategoryFilter();
+        await showMediaCategoryManager();
+    } catch (err) {
+        alert(`Kategorie konnte nicht umbenannt werden: ${err.message}`);
+    }
+}
+
+async function deleteMediaCategory(id, name) {
+    if (!confirm(`Kategorie wirklich löschen?\n\n${name || ('#' + id)}`)) return;
+    try {
+        await apiRequest('DELETE', `media/category/${id}`);
+        STATE.mediaCategories = [];
+        await ensureMediaCategoriesLoaded();
+        populateMediaCategoryFilter();
+        await showMediaCategoryManager();
+    } catch (err) {
+        alert(`Kategorie konnte nicht gelöscht werden: ${err.message}`);
+    }
+}
+
+async function showMediaMetaEditor(filename) {
+    try {
+        await ensureMediaCategoriesLoaded();
+        const info = await apiRequest('GET', `media/${encodeURIComponent(filename)}/info`);
+        const categories = STATE.mediaCategories;
+
+        const html = `<form onsubmit="submitMediaMetaForm(event, '${escAttr(filename)}')">
+            <div class="form-group">
+                <label>Datei</label>
+                <input type="text" value="${escHtml(filename)}" disabled>
+            </div>
+            <div class="form-group">
+                <label>Titel</label>
+                <input type="text" name="title" value="${escAttr(info.title || '')}" placeholder="Optionaler Medientitel">
+            </div>
+            <div class="form-group">
+                <label>Kategorie</label>
+                <select name="category_id">
+                    ${categories.map(c => `<option value="${c.id}" ${String(c.id) === String(info.category_id || 0) ? 'selected' : ''}>${escHtml(c.name)} (#${c.id})</option>`).join('')}
+                </select>
+            </div>
+            <div class="form-group">
+                <label>Datei ersetzen (optional, gleiche Endung)</label>
+                <input type="file" name="file">
+            </div>
+            <div style="display:flex; gap:12px; margin-top:24px;">
+                <button type="button" class="btn-primary" style="background:var(--bg-input); color:var(--text); border:1px solid var(--border);" onclick="closeModal()">Abbrechen</button>
+                <button type="submit" class="btn-primary">Speichern</button>
+            </div>
+        </form>`;
+
+        showModal(`Media Meta: ${filename}`, html);
+    } catch (err) {
+        showModal('Fehler', `<p>${escHtml(err.message)}</p>`);
+    }
+}
+
+async function submitMediaMetaForm(e, filename) {
+    e.preventDefault();
+    const form = e.target;
+    const btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.textContent = 'Speichert…';
+
+    const fd = new FormData();
+    fd.set('title', form.title.value || '');
+    fd.set('category_id', form.category_id.value || '0');
+    if (form.file.files && form.file.files[0]) {
+        fd.set('file', form.file.files[0]);
+    }
+
+    try {
+        await apiRequest('POST', `media/${encodeURIComponent(filename)}/update`, fd);
+        STATE.media = [];
+        await loadMedia();
+        closeModal();
+    } catch (err) {
+        alert(`Fehler beim Speichern: ${err.message}`);
+        btn.disabled = false;
+        btn.textContent = 'Speichern';
+    }
+}
+
+async function deleteMedia(filename) {
+    if (!confirm(`Datei wirklich löschen?\n\n${filename}`)) return;
+    try {
+        await apiRequest('DELETE', `media/${encodeURIComponent(filename)}/delete`);
+        closeModal();
+        STATE.media = [];
+        await loadMedia();
+    } catch (err) {
+        alert(`Löschen fehlgeschlagen: ${err.message}`);
+    }
+}
+
+async function showMediaUploadForm() {
+    try {
+        await ensureMediaCategoriesLoaded();
+        const defaultCategoryId = (STATE.mediaCategories && STATE.mediaCategories.length > 0)
+            ? String(STATE.mediaCategories[0].id)
+            : '0';
+        
+        const html = `<form onsubmit="submitMediaUploadForm(event)">
+            <div class="form-group">
+                <label>Datei</label>
+                <input type="file" name="file" required style="padding:8px; border:1px solid var(--border); border-radius:4px; background:var(--bg-input); color:var(--text); width:100%; cursor:pointer;">
+            </div>
+            <div class="form-group">
+                <label>Kategorie</label>
+                <select name="category_id">
+                    <option value="0" ${defaultCategoryId === '0' ? 'selected' : ''}>Keine Kategorie</option>
+                    ${STATE.mediaCategories.map(c => `<option value="${c.id}" ${String(c.id) === defaultCategoryId ? 'selected' : ''}>${escHtml(c.name)} (#${c.id})</option>`).join('')}
+                </select>
+            </div>
+            <div class="form-group">
+                <label>Titel (optional)</label>
+                <input type="text" name="title" placeholder="Optionaler Medientitel">
+            </div>
+            <div style="display:flex; gap:12px; margin-top:24px;">
+                <button type="button" class="btn-primary" style="background:var(--bg-input); color:var(--text); border:1px solid var(--border);" onclick="closeModal()">Abbrechen</button>
+                <button type="submit" class="btn-primary">Hochladen</button>
+            </div>
+        </form>`;
+
+        showModal('Datei hochladen', html);
+    } catch (err) {
+        showModal('Fehler', `<p>${escHtml(err.message)}</p>`);
+    }
+}
+
+async function submitMediaUploadForm(e) {
+    e.preventDefault();
+    const form = e.target;
+    const btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.textContent = 'Lädt hoch…';
+
+    const fd = new FormData();
+    if (form.file.files && form.file.files[0]) {
+        fd.set('file', form.file.files[0]);
+    }
+    fd.set('category_id', form.category_id.value || '0');
+    fd.set('title', form.title.value || '');
+
+    try {
+        await apiRequest('POST', 'media', fd);
+        STATE.media = [];
+        await loadMedia();
+        closeModal();
+    } catch (err) {
+        const selectedFile = form.file.files && form.file.files[0] ? form.file.files[0].name : '–';
+        alert(`Hochladen fehlgeschlagen: ${err.message}\nDatei: ${selectedFile}\nKategorie: ${form.category_id.value || '0'}`);
+        btn.disabled = false;
+        btn.textContent = 'Hochladen';
+    }
+}
+
+function showTemplateEditor(id = null) {
+    const t = id ? STATE.templates.find(item => item.id === id) : null;
+    const html = `<form onsubmit="submitTemplateForm(event, ${id || 'null'})">
+        <div class="form-group">
+            <label>Name</label>
+            <input type="text" name="name" value="${escAttr(t?.name || '')}" required>
+        </div>
+        <div class="form-group">
+            <label>Key</label>
+            <input type="text" name="key" value="${escAttr(t?.key || '')}">
+        </div>
+        <div class="form-group">
+            <label>Status</label>
+            <select name="active">
+                <option value="1" ${t?.active ? 'selected' : ''}>Aktiv</option>
+                <option value="0" ${t && !t.active ? 'selected' : ''}>Inaktiv</option>
+            </select>
+        </div>
+        <div class="form-group">
+            <label>Inhalt</label>
+            <textarea name="content" required style="width:100%;min-height:260px;padding:12px;border-radius:var(--radius-sm);border:1px solid var(--border);background:var(--bg-input);color:var(--text);font-family:SFMono-Regular,Menlo,Monaco,Consolas,'Liberation Mono','Courier New',monospace;font-size:12px;line-height:1.5;">${escHtml(t?.content || '')}</textarea>
+        </div>
+        <div style="display:flex; gap:12px; margin-top:24px;">
+            <button type="button" class="btn-primary" style="background:var(--bg-input); color:var(--text); border:1px solid var(--border);" onclick="closeModal()">Abbrechen</button>
+            <button type="submit" class="btn-primary">${id ? 'Speichern' : 'Anlegen'}</button>
+        </div>
+    </form>`;
+
+    showModal(id ? `Template bearbeiten #${id}` : 'Neues Template', html);
+}
+
+async function submitTemplateForm(e, id) {
+    e.preventDefault();
+    const form = e.target;
+    const btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.textContent = 'Speichert…';
+
+    const payload = {
+        name: form.name.value,
+        key: form.key.value || '',
+        content: form.content.value,
+        active: parseInt(form.active.value, 10),
+    };
+
+    try {
+        if (id) {
+            await apiRequest('PATCH', `templates/${id}`, payload);
+        } else {
+            await apiRequest('POST', 'templates', payload);
+        }
+        STATE.templates = [];
+        await loadTemplates();
+        closeModal();
+    } catch (err) {
+        alert(`Template konnte nicht gespeichert werden: ${err.message}`);
+        btn.disabled = false;
+        btn.textContent = id ? 'Speichern' : 'Anlegen';
+    }
+}
+
+async function deleteTemplate(id, name) {
+    if (!confirm(`Template wirklich löschen?\n\n${name || ('#' + id)}`)) return;
+    try {
+        await apiRequest('DELETE', `templates/${id}`);
+        closeModal();
+        STATE.templates = [];
+        await loadTemplates();
+    } catch (err) {
+        alert(`Template konnte nicht gelöscht werden: ${err.message}`);
+    }
+}
+
+function showModuleEditor(id = null) {
+    const m = id ? STATE.modules.find(item => item.id === id) : null;
+    const html = `<form onsubmit="submitModuleForm(event, ${id || 'null'})">
+        <div class="form-group">
+            <label>Name</label>
+            <input type="text" name="name" value="${escAttr(m?.name || '')}" required>
+        </div>
+        <div class="form-group">
+            <label>Key</label>
+            <input type="text" name="key" value="${escAttr(m?.key || '')}" required>
+        </div>
+        <div class="form-group">
+            <label>Input</label>
+            <textarea name="input" required style="width:100%;min-height:180px;padding:12px;border-radius:var(--radius-sm);border:1px solid var(--border);background:var(--bg-input);color:var(--text);font-family:SFMono-Regular,Menlo,Monaco,Consolas,'Liberation Mono','Courier New',monospace;font-size:12px;line-height:1.5;">${escHtml(m?.input || '')}</textarea>
+        </div>
+        <div class="form-group">
+            <label>Output</label>
+            <textarea name="output" required style="width:100%;min-height:220px;padding:12px;border-radius:var(--radius-sm);border:1px solid var(--border);background:var(--bg-input);color:var(--text);font-family:SFMono-Regular,Menlo,Monaco,Consolas,'Liberation Mono','Courier New',monospace;font-size:12px;line-height:1.5;">${escHtml(m?.output || '')}</textarea>
+        </div>
+        <div style="display:flex; gap:12px; margin-top:24px;">
+            <button type="button" class="btn-primary" style="background:var(--bg-input); color:var(--text); border:1px solid var(--border);" onclick="closeModal()">Abbrechen</button>
+            <button type="submit" class="btn-primary">${id ? 'Speichern' : 'Anlegen'}</button>
+        </div>
+    </form>`;
+
+    showModal(id ? `Modul bearbeiten #${id}` : 'Neues Modul', html);
+}
+
+async function submitModuleForm(e, id) {
+    e.preventDefault();
+    const form = e.target;
+    const btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.textContent = 'Speichert…';
+
+    const payload = {
+        name: form.name.value,
+        key: form.key.value,
+        input: form.input.value,
+        output: form.output.value,
+    };
+
+    try {
+        if (id) {
+            await apiRequest('PATCH', `modules/${id}`, payload);
+        } else {
+            await apiRequest('POST', 'modules', payload);
+        }
+        STATE.modules = [];
+        await loadModules();
+        closeModal();
+    } catch (err) {
+        alert(`Modul konnte nicht gespeichert werden: ${err.message}`);
+        btn.disabled = false;
+        btn.textContent = id ? 'Speichern' : 'Anlegen';
+    }
+}
+
+async function deleteModule(id, name) {
+    if (!confirm(`Modul wirklich löschen?\n\n${name || ('#' + id)}`)) return;
+    try {
+        await apiRequest('DELETE', `modules/${id}`);
+        closeModal();
+        STATE.modules = [];
+        await loadModules();
+    } catch (err) {
+        alert(`Modul konnte nicht gelöscht werden: ${err.message}`);
+    }
+}
+
+function renderClangs() {
+    const container = document.getElementById('clangsTable');
+    if (STATE.clangs.length === 0) {
+        container.innerHTML = '<div class="empty-state"><p>Keine Sprachen konfiguriert</p></div>';
+        return;
+    }
+
+    container.innerHTML = `<table class="data-table">
+        <thead><tr><th>ID</th><th>Code</th><th>Name</th><th>Priorität</th><th>Status</th><th>Aktion</th></tr></thead>
+        <tbody>${STATE.clangs.map(c => `
+            <tr>
+                <td class="id-col">${c.id}</td>
+                <td><code style="font-size:14px;font-weight:700">${escHtml(c.code)}</code></td>
+                <td>${escHtml(c.name)}</td>
+                <td>${c.priority}</td>
+                <td>${c.status ? '<span class="pill online">Online</span>' : '<span class="pill offline">Offline</span>'}</td>
+                <td>
+                    <div style="display:flex;gap:6px;">
+                        <button class="btn-icon" onclick="showClangEditor(${c.id})">Bearbeiten</button>
+                        <button class="btn-icon" onclick="showClangMetainfo(${c.id})">Meta</button>
+                        <button class="btn-icon btn-danger" onclick="deleteClang(${c.id}, '${escAttr(c.name || '')}')">Löschen</button>
+                    </div>
+                </td>
+            </tr>
+        `).join('')}</tbody>
+    </table>`;
+}
+
+function showClangEditor(id = null) {
+    const c = id ? STATE.clangs.find(item => item.id === id) : null;
+    const html = `<form onsubmit="submitClangForm(event, ${id || 'null'})">
+        <div class="form-group"><label>Code</label><input type="text" name="code" required value="${escAttr(c?.code || '')}" placeholder="de, en, fr"></div>
+        <div class="form-group"><label>Name</label><input type="text" name="name" required value="${escAttr(c?.name || '')}"></div>
+        <div class="form-group"><label>Priorität</label><input type="number" name="priority" value="${escAttr(String(c?.priority ?? 0))}"></div>
+        <div class="form-group"><label>Status</label>
+            <select name="status">
+                <option value="1" ${(c?.status ?? 1) ? 'selected' : ''}>Online</option>
+                <option value="0" ${(c && !c.status) ? 'selected' : ''}>Offline</option>
+            </select>
+        </div>
+        <div style="display:flex; gap:12px; margin-top:24px;">
+            <button type="button" class="btn-primary" style="background:var(--bg-input); color:var(--text); border:1px solid var(--border);" onclick="closeModal()">Abbrechen</button>
+            <button type="submit" class="btn-primary">${id ? 'Speichern' : 'Anlegen'}</button>
+        </div>
+    </form>`;
+    showModal(id ? `Sprache bearbeiten #${id}` : 'Neue Sprache', html);
+}
+
+async function submitClangForm(e, id) {
+    e.preventDefault();
+    const form = e.target;
+    const btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.textContent = 'Speichert…';
+    const payload = {
+        code: form.code.value,
+        name: form.name.value,
+        priority: parseInt(form.priority.value || '0', 10),
+        status: parseInt(form.status.value, 10),
+    };
+
+    try {
+        if (id) {
+            await apiRequest('PATCH', `system/clangs/${id}`, payload);
+        } else {
+            await apiRequest('POST', 'system/clangs', payload);
+        }
+        await loadClangs();
+        closeModal();
+    } catch (err) {
+        alert(`Sprache konnte nicht gespeichert werden: ${err.message}`);
+        btn.disabled = false;
+        btn.textContent = id ? 'Speichern' : 'Anlegen';
+    }
+}
+
+async function deleteClang(id, name) {
+    if (!confirm(`Sprache wirklich löschen?\n\n${name || ('#' + id)}`)) return;
+    try {
+        await apiRequest('DELETE', `system/clangs/${id}`);
+        await loadClangs();
+    } catch (err) {
+        alert(`Sprache konnte nicht gelöscht werden: ${err.message}`);
+    }
+}
+
+// ==================== METAINFO ====================
+
+async function loadMetainfo() {
+    const container = document.getElementById('metainfoTable');
+    try {
+        const [typesRes, fieldsRes] = await Promise.all([
+            apiRequest('GET', 'metainfo/types'),
+            apiRequest('GET', 'metainfo/fields?per_page=1000'),
+        ]);
+        STATE.metainfoTypes = unwrapListPayload(typesRes);
+        STATE.metainfoFields = unwrapListPayload(fieldsRes);
+        renderMetainfoFields();
+    } catch (err) {
+        container.innerHTML = `<div class="empty-state"><p>Fehler: ${escHtml(err.message)}</p></div>`;
+    }
+}
+
+function getMetainfoTypeLabel(typeId) {
+    const t = STATE.metainfoTypes.find(item => Number(item.id) === Number(typeId));
+    if (!t) return `#${typeId}`;
+    return `${t.label} (#${t.id})`;
+}
+
+function renderMetainfoFields() {
+    const container = document.getElementById('metainfoTable');
+    if (!container) return;
+
+    const prefix = document.getElementById('metainfoPrefixFilter')?.value || '';
+    let fields = STATE.metainfoFields;
+    if (prefix) {
+        fields = fields.filter(f => String(f.name || '').startsWith(prefix));
+    }
+
+    if (fields.length === 0) {
+        container.innerHTML = '<div class="empty-state"><p>Keine Metafelder gefunden</p></div>';
+        return;
+    }
+
+    container.innerHTML = `<table class="data-table">
+        <thead><tr><th>ID</th><th>Name</th><th>Titel</th><th>Typ</th><th>Prio</th><th>Aktion</th></tr></thead>
+        <tbody>${fields.map(f => `
+            <tr>
+                <td class="id-col">${f.id}</td>
+                <td><code>${escHtml(f.name || '')}</code></td>
+                <td>${escHtml(f.title || '–')}</td>
+                <td>${escHtml(getMetainfoTypeLabel(f.type_id))}</td>
+                <td>${f.priority ?? 0}</td>
+                <td>
+                    <div style="display:flex;gap:6px;">
+                        <button class="btn-icon" onclick="showMetainfoFieldEditor(${f.id})">Bearbeiten</button>
+                        <button class="btn-icon btn-danger" onclick="deleteMetainfoField(${f.id}, '${escAttr(f.name || '')}')">Löschen</button>
+                    </div>
+                </td>
+            </tr>
+        `).join('')}</tbody>
+    </table>`;
+}
+
+async function showMetainfoFieldEditor(id = null) {
+    try {
+        if (STATE.metainfoTypes.length === 0) {
+            STATE.metainfoTypes = unwrapListPayload(await apiRequest('GET', 'metainfo/types'));
+        }
+
+        const field = id ? await apiRequest('GET', `metainfo/fields/${id}`) : null;
+        const typeOptions = STATE.metainfoTypes
+            .map(t => `<option value="${t.id}" ${Number(field?.type_id) === Number(t.id) ? 'selected' : ''}>${escHtml(t.label)} (#${t.id})</option>`)
+            .join('');
+
+        const html = `<form onsubmit="submitMetainfoFieldForm(event, ${id || 'null'})">
+            <div class="form-group"><label>Name</label><input type="text" name="name" ${id ? 'disabled' : 'required'} value="${escAttr(field?.name || '')}" placeholder="z. B. art_seo_title"></div>
+            <div class="form-group"><label>Titel</label><input type="text" name="title" required value="${escAttr(field?.title || '')}"></div>
+            <div class="form-group"><label>Typ</label><select name="type_id" ${id ? 'disabled' : ''}>${typeOptions}</select></div>
+            <div class="form-group"><label>Priorität</label><input type="number" name="priority" value="${escAttr(String(field?.priority ?? 0))}"></div>
+            <div class="form-group"><label>Default</label><input type="text" name="default" value="${escAttr(field?.default || '')}"></div>
+            <div class="form-group"><label>Parameter</label><input type="text" name="params" value="${escAttr(field?.params || '')}"></div>
+            <div class="form-group"><label>Validate</label><input type="text" name="validate" value="${escAttr(field?.validate || '')}"></div>
+            <div class="form-group"><label>Restrictions</label><input type="text" name="restrictions" value="${escAttr(field?.restrictions || '')}"></div>
+            <div class="form-group"><label>Callback</label><input type="text" name="callback" value="${escAttr(field?.callback || '')}"></div>
+            <div class="form-group"><label>Attributes</label><input type="text" name="attributes" value="${escAttr(field?.attributes || '')}"></div>
+            <div style="display:flex; gap:12px; margin-top:24px;">
+                <button type="button" class="btn-primary" style="background:var(--bg-input); color:var(--text); border:1px solid var(--border);" onclick="closeModal()">Abbrechen</button>
+                <button type="submit" class="btn-primary">${id ? 'Speichern' : 'Anlegen'}</button>
+            </div>
+        </form>`;
+
+        showModal(id ? `Metafeld bearbeiten #${id}` : 'Neues Metafeld', html);
+    } catch (err) {
+        showModal('Fehler', `<p>${escHtml(err.message)}</p>`);
+    }
+}
+
+async function submitMetainfoFieldForm(e, id) {
+    e.preventDefault();
+    const form = e.target;
+    const btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.textContent = 'Speichert…';
+
+    const payload = {
+        title: form.title.value,
+        priority: parseInt(form.priority.value || '0', 10),
+        attributes: form.attributes.value,
+        default: form.default.value,
+        params: form.params.value,
+        validate: form.validate.value,
+        restrictions: form.restrictions.value,
+        callback: form.callback.value,
+    };
+
+    try {
+        if (id) {
+            await apiRequest('PATCH', `metainfo/fields/${id}`, payload);
+        } else {
+            await apiRequest('POST', 'metainfo/fields', {
+                name: form.name.value,
+                type_id: parseInt(form.type_id.value, 10),
+                ...payload,
+            });
+        }
+        await loadMetainfo();
+        closeModal();
+    } catch (err) {
+        alert(`Metafeld konnte nicht gespeichert werden: ${err.message}`);
+        btn.disabled = false;
+        btn.textContent = id ? 'Speichern' : 'Anlegen';
+    }
+}
+
+async function deleteMetainfoField(id, name) {
+    if (!confirm(`Metafeld wirklich löschen?\n\n${name || ('#' + id)}`)) return;
+    try {
+        await apiRequest('DELETE', `metainfo/fields/${id}`);
+        await loadMetainfo();
+    } catch (err) {
+        alert(`Metafeld konnte nicht gelöscht werden: ${err.message}`);
+    }
+}
+
+function metainfoValuePath(type, idOrFilename, clangId = null) {
+    if (type === 'article') {
+        const q = clangId ? `?clang_id=${encodeURIComponent(clangId)}` : '';
+        return `structure/articles/${idOrFilename}/metainfo${q}`;
+    }
+    if (type === 'category') {
+        const q = clangId ? `?clang_id=${encodeURIComponent(clangId)}` : '';
+        return `structure/categories/${idOrFilename}/metainfo${q}`;
+    }
+    if (type === 'media') {
+        return `media/${encodeURIComponent(String(idOrFilename))}/metainfo`;
+    }
+    if (type === 'clang') {
+        return `system/clangs/${idOrFilename}/metainfo`;
+    }
+    throw new Error(`Unbekannter Metainfo-Typ: ${type}`);
+}
+
+function metainfoPrefixForType(type) {
+    const map = {
+        article: 'art_',
+        category: 'cat_',
+        media: 'med_',
+        clang: 'clang_',
+    };
+    return map[type] || '';
+}
+
+function stringifyMetainfoValue(value) {
+    if (value === null || value === undefined) return '';
+    if (typeof value === 'string') return value;
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return String(value);
+    }
+}
+
+async function showMetainfoValuesEditor(type, idOrFilename, label, clangId = null) {
+    try {
+        if (STATE.metainfoFields.length === 0) {
+            try {
+                STATE.metainfoFields = unwrapListPayload(await apiRequest('GET', 'metainfo/fields?per_page=1000'));
+            } catch (e) {
+                console.warn('Metainfo-Felddefinitionen konnten nicht geladen werden:', e);
+            }
+        }
+
+        const prefix = metainfoPrefixForType(type);
+        const allFields = STATE.metainfoFields.filter(f => String(f.name || '').startsWith(prefix));
+        const path = metainfoValuePath(type, idOrFilename, clangId);
+        const payload = await apiRequest('GET', path);
+        const values = payload && typeof payload.data === 'object' ? payload.data : {};
+
+        let fieldNames = allFields.map(f => f.name);
+        if (fieldNames.length === 0) {
+            fieldNames = Object.keys(values).sort();
+        }
+
+        const rows = fieldNames.map(name => {
+            const def = allFields.find(f => f.name === name);
+            const title = def?.title || name;
+            const raw = stringifyMetainfoValue(values[name]);
+            const useTextarea = raw.length > 140;
+
+            return `<div class="form-group">
+                <label>${escHtml(title)} <span style="opacity:.6; font-weight:400;">(${escHtml(name)})</span></label>
+                ${useTextarea
+                    ? `<textarea name="${escAttr(name)}" data-meta-field="1" style="width:100%;min-height:90px;padding:12px;border-radius:var(--radius-sm);border:1px solid var(--border);background:var(--bg-input);color:var(--text);">${escHtml(raw)}</textarea>`
+                    : `<input type="text" name="${escAttr(name)}" data-meta-field="1" value="${escAttr(raw)}">`
+                }
+            </div>`;
+        }).join('');
+
+        const body = rows.length > 0
+            ? `<form onsubmit="submitMetainfoValuesForm(event, '${escAttr(type)}', '${escAttr(String(idOrFilename))}', ${clangId === null ? 'null' : Number(clangId)})">${rows}
+                <div style="display:flex; gap:12px; margin-top:24px;">
+                    <button type="button" class="btn-primary" style="background:var(--bg-input); color:var(--text); border:1px solid var(--border);" onclick="closeModal()">Abbrechen</button>
+                    <button type="submit" class="btn-primary">Speichern</button>
+                </div>
+            </form>`
+            : '<p>Keine Metafelder für diesen Typ definiert.</p>';
+
+        showModal(`Metainfo: ${label}`, body);
+    } catch (err) {
+        showModal('Fehler', `<p>${escHtml(err.message)}</p>`);
+    }
+}
+
+async function submitMetainfoValuesForm(e, type, idOrFilename, clangId) {
+    e.preventDefault();
+    const form = e.target;
+    const btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.textContent = 'Speichert…';
+
+    const payload = {};
+    form.querySelectorAll('[data-meta-field="1"]').forEach(el => {
+        payload[el.name] = el.value;
+    });
+
+    try {
+        const realClang = clangId === null ? null : Number(clangId);
+        const path = metainfoValuePath(type, idOrFilename, realClang);
+        await apiRequest('PATCH', path, payload);
+        closeModal();
+    } catch (err) {
+        alert(`Metainfo konnte nicht gespeichert werden: ${err.message}`);
+        btn.disabled = false;
+        btn.textContent = 'Speichern';
+    }
+}
+
+async function showArticleMetainfo(articleId, clangId) {
+    await showMetainfoValuesEditor('article', articleId, `Artikel #${articleId}`, clangId || STATE.currentClang || null);
+}
+
+async function showCategoryMetainfo(categoryId, clangId) {
+    await showMetainfoValuesEditor('category', categoryId, `Kategorie #${categoryId}`, clangId || STATE.currentClang || null);
+}
+
+async function showMediaMetainfoValues(filename) {
+    await showMetainfoValuesEditor('media', filename, filename, null);
+}
+
+async function showClangMetainfo(clangId) {
+    await showMetainfoValuesEditor('clang', clangId, `Sprache #${clangId}`, null);
+}
+
+async function showArticleSlicesManager(articleId, clangId) {
+    try {
+        if (STATE.modules.length === 0) {
+            STATE.modules = unwrapListPayload(await apiRequest('GET', 'modules'));
+        }
+        const payload = await apiRequest('GET', `structure/articles/${articleId}/slices?clang_id=${encodeURIComponent(clangId)}&per_page=200`);
+        const slices = unwrapListPayload(payload);
+
+        const rows = slices.map(s => {
+            const module = STATE.modules.find(m => Number(m.id) === Number(s.module_id));
+            return `<tr>
+                <td class="id-col">${s.id}</td>
+                <td>${escHtml(module?.name || ('#' + s.module_id))}</td>
+                <td>${s.ctype_id}</td>
+                <td>${s.priority}</td>
+                <td>${s.status ? '<span class="pill online">Online</span>' : '<span class="pill offline">Offline</span>'}</td>
+                <td>
+                    <div style="display:flex;gap:6px;">
+                        <button class="btn-icon" onclick="showSliceEditor(${articleId}, ${s.id}, ${clangId})">Bearbeiten</button>
+                        <button class="btn-icon btn-danger" onclick="deleteArticleSlice(${articleId}, ${s.id}, ${clangId})">Löschen</button>
+                    </div>
+                </td>
+            </tr>`;
+        }).join('');
+
+        const html = `<div style="display:flex;justify-content:flex-end;gap:8px;margin-bottom:12px;">
+            <button class="btn-icon" onclick="showArticleSlicesBlockMode(${articleId}, ${clangId})">Block-Mode</button>
+            <button class="btn-icon" onclick="showSliceEditor(${articleId}, null, ${clangId})">Neuer Slice</button>
+        </div>
+        <table class="data-table">
+            <thead><tr><th>ID</th><th>Modul</th><th>CType</th><th>Prio</th><th>Status</th><th>Aktion</th></tr></thead>
+            <tbody>${rows || '<tr><td colspan="6" style="padding:16px;">Keine Slices vorhanden.</td></tr>'}</tbody>
+        </table>`;
+
+        showModal(`Slices für Artikel #${articleId}`, html);
+    } catch (err) {
+        showModal('Fehler', `<p>${escHtml(err.message)}</p>`);
+    }
+}
+
+function renderSliceFieldControl(name, value) {
+    const raw = String(value ?? '');
+    const isTextArea = /^value\d+$/.test(name);
+    if (isTextArea) {
+        return `<div class="form-group" style="margin:0;"><label>${name}</label><textarea name="${name}" style="width:100%;min-height:80px;padding:10px;border-radius:var(--radius-sm);border:1px solid var(--border);background:var(--bg-input);color:var(--text);">${escHtml(raw)}</textarea></div>`;
+    }
+    return `<div class="form-group" style="margin:0;"><label>${name}</label><input type="text" name="${name}" value="${escAttr(raw)}"></div>`;
+}
+
+function sliceValueFieldNames() {
+    return Array.from({ length: 19 }, (_, i) => `value${i + 1}`);
+}
+
+function sliceAssetFieldNames() {
+    const fields = [];
+    for (let i = 1; i <= 10; i++) {
+        fields.push(`media${i}`, `medialist${i}`, `link${i}`, `linklist${i}`);
+    }
+    return fields;
+}
+
+async function showArticleSlicesBlockMode(articleId, clangId) {
+    try {
+        if (STATE.modules.length === 0) {
+            STATE.modules = unwrapListPayload(await apiRequest('GET', 'modules'));
+        }
+        const listPayload = await apiRequest('GET', `structure/articles/${articleId}/slices?clang_id=${encodeURIComponent(clangId)}&per_page=200`);
+        const sliceList = unwrapListPayload(listPayload);
+        const detailSlices = await Promise.all(sliceList.map(s => apiRequest('GET', `structure/articles/${articleId}/slices/${s.id}`)));
+
+        const primaryFields = ['value1', 'value2', 'value3', 'value4', 'media1', 'medialist1', 'link1', 'linklist1'];
+        const allFields = [...sliceValueFieldNames(), ...sliceAssetFieldNames()];
+        const secondaryFields = allFields.filter(name => !primaryFields.includes(name));
+
+        const blocks = detailSlices.map(s => {
+            const module = STATE.modules.find(m => Number(m.id) === Number(s.module_id));
+            const primaryControls = primaryFields.map(name => renderSliceFieldControl(name, s[name])).join('');
+            const secondaryControls = secondaryFields.map(name => renderSliceFieldControl(name, s[name])).join('');
+
+            return `<form onsubmit="submitSliceBlockForm(event, ${articleId}, ${s.id}, ${clangId})" style="border:1px solid var(--border);border-radius:8px;padding:12px;background:var(--bg-card);margin-bottom:12px;">
+                <div style="display:flex;justify-content:space-between;align-items:center;gap:8px;margin-bottom:10px;">
+                    <div style="font-weight:600;">#${s.id} · ${escHtml(module?.name || ('Modul #' + s.module_id))}</div>
+                    <div style="display:flex;gap:6px;">
+                        <button type="button" class="btn-icon" onclick="showSliceEditor(${articleId}, ${s.id}, ${clangId})">Voll-Editor</button>
+                        <button type="button" class="btn-icon btn-danger" onclick="deleteArticleSlice(${articleId}, ${s.id}, ${clangId})">Löschen</button>
+                    </div>
+                </div>
+                <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;">
+                    ${primaryControls}
+                </div>
+                <details style="margin-top:8px;">
+                    <summary style="cursor:pointer;">Alle weiteren Felder (value5-19, media/link 2-10)</summary>
+                    <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:8px;">
+                        ${secondaryControls}
+                    </div>
+                </details>
+                <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:10px;">
+                    <button type="submit" class="btn-primary">Block speichern</button>
+                </div>
+            </form>`;
+        }).join('');
+
+        const html = `<div style="display:flex;justify-content:flex-end;gap:8px;margin-bottom:12px;">
+            <button class="btn-icon" onclick="showArticleSlicesManager(${articleId}, ${clangId})">Tabellen-Mode</button>
+            <button class="btn-icon" onclick="showSliceEditor(${articleId}, null, ${clangId})">Neuer Slice</button>
+        </div>${blocks || '<p>Keine Slices vorhanden.</p>'}`;
+
+        showModal(`Slices Block-Mode für Artikel #${articleId}`, html);
+    } catch (err) {
+        showModal('Fehler', `<p>${escHtml(err.message)}</p>`);
+    }
+}
+
+function collectSliceBlockPayload(form) {
+    const payload = {};
+    for (const key of [...sliceValueFieldNames(), ...sliceAssetFieldNames()]) {
+        if (form[key]) payload[key] = form[key].value;
+    }
+    return payload;
+}
+
+async function submitSliceBlockForm(e, articleId, sliceId, clangId) {
+    e.preventDefault();
+    const form = e.target;
+    const btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.textContent = 'Speichert…';
+
+    try {
+        const payload = collectSliceBlockPayload(form);
+        await apiRequest('PATCH', `structure/articles/${articleId}/slices/${sliceId}`, payload);
+        btn.textContent = 'Gespeichert';
+        setTimeout(() => {
+            btn.disabled = false;
+            btn.textContent = 'Block speichern';
+        }, 700);
+    } catch (err) {
+        alert(`Block konnte nicht gespeichert werden: ${err.message}`);
+        btn.disabled = false;
+        btn.textContent = 'Block speichern';
+    }
+}
+
+async function showSliceEditor(articleId, sliceId = null, clangId = null) {
+    try {
+        if (STATE.modules.length === 0) {
+            STATE.modules = unwrapListPayload(await apiRequest('GET', 'modules'));
+        }
+
+        const isEdit = sliceId !== null && sliceId !== undefined;
+        const slice = isEdit ? await apiRequest('GET', `structure/articles/${articleId}/slices/${sliceId}`) : null;
+        const resolvedClang = Number(clangId || slice?.clang_id || STATE.currentClang || 1);
+
+        const moduleOptions = STATE.modules
+            .map(m => `<option value="${m.id}" ${Number(slice?.module_id) === Number(m.id) ? 'selected' : ''}>${escHtml(m.name)} (#${m.id})</option>`)
+            .join('');
+
+        const fieldNames = [];
+        for (let i = 1; i <= 19; i++) fieldNames.push(`value${i}`);
+        for (let i = 1; i <= 10; i++) {
+            fieldNames.push(`media${i}`);
+            fieldNames.push(`medialist${i}`);
+            fieldNames.push(`link${i}`);
+            fieldNames.push(`linklist${i}`);
+        }
+
+        const contentRows = fieldNames.map(name => {
+            const val = slice ? (slice[name] ?? '') : '';
+            return `<div class="form-group"><label>${name}</label><input type="text" name="${name}" value="${escAttr(String(val ?? ''))}"></div>`;
+        }).join('');
+
+        const html = `<form onsubmit="submitSliceForm(event, ${articleId}, ${isEdit ? sliceId : 'null'}, ${resolvedClang})">
+            <div class="form-group"><label>Modul</label><select name="module_id" ${isEdit ? 'disabled' : ''} required>${moduleOptions}</select></div>
+            <div class="form-group"><label>CType</label><input type="number" name="ctype_id" min="1" value="${escAttr(String(slice?.ctype_id ?? 1))}" ${isEdit ? 'disabled' : ''}></div>
+            <div class="form-group"><label>Clang</label><input type="number" name="clang_id" value="${resolvedClang}" ${isEdit ? 'disabled' : ''}></div>
+            <details style="margin-top:8px;" open>
+                <summary style="cursor:pointer; font-weight:600; margin-bottom:8px;">Inhaltsfelder</summary>
+                ${contentRows}
+            </details>
+            <div style="display:flex; gap:12px; margin-top:24px;">
+                <button type="button" class="btn-primary" style="background:var(--bg-input); color:var(--text); border:1px solid var(--border);" onclick="showArticleSlicesManager(${articleId}, ${resolvedClang})">Zurück</button>
+                <button type="submit" class="btn-primary">${isEdit ? 'Speichern' : 'Anlegen'}</button>
+            </div>
+        </form>`;
+
+        showModal(isEdit ? `Slice bearbeiten #${sliceId}` : `Neuer Slice für Artikel #${articleId}`, html);
+    } catch (err) {
+        showModal('Fehler', `<p>${escHtml(err.message)}</p>`);
+    }
+}
+
+function collectSlicePayloadFromForm(form) {
+    const payload = {};
+    for (let i = 1; i <= 19; i++) {
+        const key = `value${i}`;
+        if (form[key] && form[key].value !== '') payload[key] = form[key].value;
+    }
+    for (let i = 1; i <= 10; i++) {
+        for (const prefix of ['media', 'medialist', 'link', 'linklist']) {
+            const key = `${prefix}${i}`;
+            if (form[key] && form[key].value !== '') payload[key] = form[key].value;
+        }
+    }
+    return payload;
+}
+
+async function submitSliceForm(e, articleId, sliceId, clangId) {
+    e.preventDefault();
+    const form = e.target;
+    const btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.textContent = 'Speichert…';
+
+    try {
+        const contentPayload = collectSlicePayloadFromForm(form);
+        if (!sliceId && Object.keys(contentPayload).length === 0) {
+            contentPayload.value1 = '';
+        }
+
+        if (sliceId) {
+            if (Object.keys(contentPayload).length === 0) {
+                throw new Error('Bitte mindestens ein Inhaltsfeld ausfüllen.');
+            }
+            await apiRequest('PATCH', `structure/articles/${articleId}/slices/${sliceId}`, contentPayload);
+        } else {
+            await apiRequest('POST', `structure/articles/${articleId}/slices`, {
+                module_id: parseInt(form.module_id.value, 10),
+                ctype_id: parseInt(form.ctype_id.value || '1', 10),
+                clang_id: parseInt(form.clang_id.value || String(clangId || STATE.currentClang || 1), 10),
+                ...contentPayload,
+            });
+        }
+
+        await showArticleSlicesManager(articleId, clangId || STATE.currentClang || 1);
+    } catch (err) {
+        alert(`Slice konnte nicht gespeichert werden: ${err.message}`);
+        btn.disabled = false;
+        btn.textContent = sliceId ? 'Speichern' : 'Anlegen';
+    }
+}
+
+async function deleteArticleSlice(articleId, sliceId, clangId) {
+    if (!confirm(`Slice #${sliceId} wirklich löschen?`)) return;
+    try {
+        await apiRequest('DELETE', `structure/articles/${articleId}/slices/${sliceId}`);
+        await showArticleSlicesManager(articleId, clangId || STATE.currentClang || 1);
+    } catch (err) {
+        alert(`Slice konnte nicht gelöscht werden: ${err.message}`);
+    }
+}
+
+// ==================== ARTICLE DETAIL ====================
+
+function showArticleEditor(article) {
+    const templateOptions = [
+        '<option value="0">(Kein Template)</option>',
+        ...STATE.templates.map(t => `<option value="${t.id}" ${Number(article.template_id) === Number(t.id) ? 'selected' : ''}>${escHtml(t.name)} (#${t.id})</option>`),
+    ].join('');
+
+    const html = `<form onsubmit="submitArticleForm(event, ${article.id})">
+        <div class="form-group"><label>Name</label><input type="text" name="name" required value="${escAttr(article.name || '')}"></div>
+        <div class="form-group"><label>Priorität</label><input type="number" name="priority" value="${escAttr(String(article.priority ?? 0))}"></div>
+        <div class="form-group"><label>Status</label>
+            <select name="status">
+                <option value="1" ${article.status ? 'selected' : ''}>Online</option>
+                <option value="0" ${article.status ? '' : 'selected'}>Offline</option>
+            </select>
+        </div>
+        <div class="form-group"><label>Template</label>
+            <select name="template_id">${templateOptions}</select>
+        </div>
+        <div style="display:flex; gap:12px; margin-top:24px;">
+            <button type="button" class="btn-primary" style="background:var(--bg-input); color:var(--text); border:1px solid var(--border);" onclick="showArticleDetail(${article.id})">Zurück</button>
+            <button type="submit" class="btn-primary">Speichern</button>
+        </div>
+    </form>`;
+
+    showModal(`Artikel bearbeiten: ${article.name}`, html);
+}
+
+async function showArticleEditorById(articleId) {
+    try {
+        if (STATE.templates.length === 0) {
+            STATE.templates = unwrapListPayload(await apiRequest('GET', 'templates'));
+        }
+        const article = await apiRequest('GET', `structure/articles/${articleId}`);
+        showArticleEditor(article);
+    } catch (err) {
+        showModal('Fehler', `<p>${escHtml(err.message)}</p>`);
+    }
+}
+
+async function submitArticleForm(e, articleId) {
+    e.preventDefault();
+    const form = e.target;
+    const btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.textContent = 'Speichert…';
+
+    try {
+        await apiRequest('PATCH', `structure/articles/${articleId}`, {
+            name: form.name.value,
+            priority: parseInt(form.priority.value || '0', 10),
+            status: parseInt(form.status.value, 10),
+            template_id: parseInt(form.template_id.value || '0', 10),
+        });
+
+        STATE.articles = [];
+        await loadStructure();
+        await showArticleDetail(articleId);
+    } catch (err) {
+        alert(`Artikel konnte nicht gespeichert werden: ${err.message}`);
+        btn.disabled = false;
+        btn.textContent = 'Speichern';
+    }
+}
+
+async function showArticleDetail(id) {
+    try {
+        if (STATE.templates.length === 0) {
+            STATE.templates = unwrapListPayload(await apiRequest('GET', 'templates'));
+        }
+
+        const article = await apiRequest('GET', `structure/articles/${id}`);
+        const template = STATE.templates.find(t => t.id === article.template_id);
+
+        let html = [
+            ['ID', article.id],
+            ['Name', article.name],
+            ['Kategoriename', article.catname],
+            ['Parent ID', article.parent_id],
+            ['Clang', article.clang_id],
+            ['Template', template ? template.name : `ID: ${article.template_id}`],
+            ['Priorität', article.priority],
+            ['Startartikel', article.startarticle ? 'Ja' : 'Nein'],
+            ['Status', article.status ? 'Online' : 'Offline'],
+            ['Erstellt', `${formatDate(article.createdate)} von ${article.createuser}`],
+            ['Aktualisiert', `${formatDate(article.updatedate)} von ${article.updateuser}`],
+        ].map(([l, v]) => `<div class="detail-row"><span class="detail-label">${l}</span><span class="detail-value">${escHtml(String(v || '–'))}</span></div>`).join('');
+
+        html += `<div style="margin-top:16px;display:flex;gap:8px;flex-wrap:wrap;">
+            <button class="btn-icon" onclick="showArticleEditorById(${article.id})">Artikel bearbeiten</button>
+            <button class="btn-icon" onclick="openPagebuilderEditor(${article.id}, ${article.clang_id || STATE.currentClang || 1}, true)">Pagebuilder bearbeiten</button>
+            <button class="btn-icon" onclick="showArticleMetainfo(${article.id}, ${article.clang_id || STATE.currentClang || 1})">Metainfo-Werte bearbeiten</button>
+            <button class="btn-icon" onclick="showArticleSlicesManager(${article.id}, ${article.clang_id || STATE.currentClang || 1})">Slices verwalten</button>
+            <button class="btn-icon" onclick="showArticleSlicesBlockMode(${article.id}, ${article.clang_id || STATE.currentClang || 1})">Slice Block-Mode</button>
+            <button class="btn-icon btn-danger" onclick="deleteStructureArticle(${article.id}, '${escAttr(article.name || '')}')">Artikel löschen</button>
+        </div>`;
+
+        showModal(`Artikel: ${article.name}`, html);
+    } catch (err) {
+        showModal('Fehler', `<p>${escHtml(err.message)}</p>`);
+    }
+}
+
+// ==================== GLOBAL SEARCH ====================
+
+let searchDebounce = null;
+function handleGlobalSearch(query) {
+    clearTimeout(searchDebounce);
+    if (query.length < 2) return;
+    searchDebounce = setTimeout(() => {
+        navigateTo('search');
+        performSearch(query);
+    }, 300);
+}
+
+async function performSearch(query) {
+    const container = document.getElementById('searchResults');
+    container.innerHTML = '<div class="loading-overlay"><span class="spinner"></span> Suche…</div>';
+
+    const q = query.toLowerCase();
+
+    // Search articles
+    const matchedArticles = STATE.articles.filter(a =>
+        (a.name || '').toLowerCase().includes(q) ||
+        String(a.id).includes(q)
+    );
+
+    // Search media
+    const matchedMedia = STATE.media.filter(m =>
+        (m.filename || '').toLowerCase().includes(q) ||
+        (m.title || '').toLowerCase().includes(q)
+    );
+
+    // Search templates
+    const matchedTemplates = STATE.templates.filter(t =>
+        (t.name || '').toLowerCase().includes(q)
+    );
+
+    // Search modules
+    const matchedModules = STATE.modules.filter(m =>
+        (m.name || '').toLowerCase().includes(q)
+    );
+
+    let html = '';
+
+    if (matchedArticles.length > 0) {
+        html += `<div style="padding:16px 24px 8px"><strong>Artikel (${matchedArticles.length})</strong></div>
+            <table class="data-table"><thead><tr><th>ID</th><th>Name</th><th>Status</th></tr></thead>
+            <tbody>${matchedArticles.slice(0, 20).map(a => `
+                <tr onclick="showArticleDetail(${a.id})" style="cursor:pointer">
+                    <td class="id-col">${a.id}</td><td>${escHtml(a.name)}</td>
+                    <td>${a.status ? '<span class="pill online">Online</span>' : '<span class="pill offline">Offline</span>'}</td>
+                </tr>`).join('')}</tbody></table>`;
+    }
+
+    if (matchedMedia.length > 0) {
+        html += `<div style="padding:16px 24px 8px"><strong>Medien (${matchedMedia.length})</strong></div>
+            <table class="data-table"><thead><tr><th>Dateiname</th><th>Typ</th><th>Größe</th></tr></thead>
+            <tbody>${matchedMedia.slice(0, 20).map(m => `
+                <tr onclick="showMediaDetail('${escAttr(m.filename)}')" style="cursor:pointer">
+                    <td>${escHtml(m.filename)}</td><td>${shortType(m.filetype)}</td><td>${formatSize(m.filesize)}</td>
+                </tr>`).join('')}</tbody></table>`;
+    }
+
+    if (matchedTemplates.length > 0) {
+        html += `<div style="padding:16px 24px 8px"><strong>Templates (${matchedTemplates.length})</strong></div>
+            <table class="data-table"><thead><tr><th>ID</th><th>Name</th></tr></thead>
+            <tbody>${matchedTemplates.map(t => `
+                <tr onclick="showTemplateDetail(${t.id})" style="cursor:pointer">
+                    <td class="id-col">${t.id}</td><td>${escHtml(t.name)}</td>
+                </tr>`).join('')}</tbody></table>`;
+    }
+
+    if (matchedModules.length > 0) {
+        html += `<div style="padding:16px 24px 8px"><strong>Module (${matchedModules.length})</strong></div>
+            <table class="data-table"><thead><tr><th>ID</th><th>Name</th></tr></thead>
+            <tbody>${matchedModules.map(m => `
+                <tr onclick="showModuleDetail(${m.id})" style="cursor:pointer">
+                    <td class="id-col">${m.id}</td><td>${escHtml(m.name)}</td>
+                </tr>`).join('')}</tbody></table>`;
+    }
+
+    if (!html) {
+        html = `<div class="empty-state"><p>Keine Ergebnisse für „${escHtml(query)}"</p></div>`;
+    }
+
+    container.innerHTML = html;
+}
+
+// ==================== API LOG ====================
+
+function renderApiLog() {
+    const container = document.getElementById('apiLogList');
+    if (STATE.apiLog.length === 0) {
+        container.innerHTML = '<div class="empty-state"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg><p>Noch keine API-Requests aufgezeichnet.</p></div>';
+        return;
+    }
+
+    container.innerHTML = STATE.apiLog.map(e => `
+        <div class="api-log-entry">
+            <span class="api-log-method ${e.method}">${e.method}</span>
+            <span class="api-log-url">/api/${escHtml(e.path)}</span>
+            <span class="api-log-status ${e.status >= 200 && e.status < 400 ? 'ok' : 'err'}">${e.status || 'ERR'}</span>
+            <span class="api-log-time">${e.elapsed}ms</span>
+        </div>
+    `).join('');
+}
+
+function clearApiLog() {
+    STATE.apiLog = [];
+    document.getElementById('badgeLog').textContent = '0';
+    renderApiLog();
+}
+
+// ==================== MODAL ====================
+
+function showModal(title, contentHtml) {
+    document.getElementById('modalTitle').textContent = title;
+    document.getElementById('modalBody').innerHTML = contentHtml;
+    document.getElementById('detailModal').classList.add('active');
+}
+
+function closeModal() {
+    document.getElementById('detailModal').classList.remove('active');
+}
+
+function showToast(msg, type = 'success') {
+    let t = document.getElementById('_toast');
+    if (!t) {
+        t = document.createElement('div');
+        t.id = '_toast';
+        t.style.cssText = 'position:fixed;bottom:24px;right:24px;z-index:9999;padding:12px 20px;border-radius:8px;font-size:13px;font-weight:600;box-shadow:0 4px 12px rgba(0,0,0,.2);transition:opacity .3s;max-width:340px;';
+        document.body.appendChild(t);
+    }
+    t.textContent = msg;
+    t.style.background = type === 'error' ? '#e8453c' : '#10b981';
+    t.style.color = '#fff';
+    t.style.opacity = '1';
+    clearTimeout(t._timer);
+    t._timer = setTimeout(() => { t.style.opacity = '0'; }, 3000);
+}
+
+document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') closeModal();
+});
+
+// ==================== HELPERS ====================
+
+function escHtml(str) {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+}
+
+function escAttr(str) {
+    return String(str).replace(/'/g, "\\'").replace(/"/g, '&quot;');
+}
+
+function formatDate(dateStr) {
+    if (!dateStr) return '–';
+    try {
+        const d = new Date(dateStr);
+        return d.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' }) +
+            ' ' + d.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+    } catch {
+        return dateStr;
+    }
+}
+
+function formatSize(bytes) {
+    if (!bytes) return '–';
+    const units = ['B', 'KB', 'MB', 'GB'];
+    let i = 0;
+    let size = parseInt(bytes, 10);
+    while (size >= 1024 && i < units.length - 1) { size /= 1024; i++; }
+    return `${size.toFixed(i > 0 ? 1 : 0)} ${units[i]}`;
+}
+
+function shortType(type) {
+    if (!type) return '–';
+    const map = {
+        'image/jpeg': 'JPEG', 'image/png': 'PNG', 'image/gif': 'GIF', 'image/svg+xml': 'SVG',
+        'image/webp': 'WebP', 'application/pdf': 'PDF', 'video/mp4': 'MP4',
+        'audio/mpeg': 'MP3', 'text/plain': 'TXT', 'text/html': 'HTML',
+        'application/zip': 'ZIP',
+    };
+    return map[type] || type.split('/').pop().toUpperCase();
+}
+
+function fileEmoji(type) {
+    if (!type) return '📄';
+    if (type.startsWith('image/')) return '🖼';
+    if (type.startsWith('video/')) return '🎬';
+    if (type.startsWith('audio/')) return '🎵';
+    if (type.includes('pdf')) return '📕';
+    if (type.includes('zip') || type.includes('rar')) return '📦';
+    if (type.includes('word') || type.includes('doc')) return '📝';
+    if (type.includes('sheet') || type.includes('excel')) return '📊';
+    return '📄';
+}
+
+// ==================== SYSTEM DASHBOARD ====================
+
+function toggleAccordion(header) {
+    header.classList.toggle('collapsed');
+    const content = header.nextElementSibling;
+    if (content && content.classList.contains('accordion-content')) {
+        content.classList.toggle('collapsed');
+    }
+}
+
+async function loadSystemDashboard() {
+    const container = document.getElementById('systemDashboard');
+    try {
+        const html = `
+        <div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(180px, 1fr)); gap:12px; margin-bottom:20px;">
+            <div class="stat-card" style="background:var(--bg-card); padding:16px; border-radius:6px; border:1px solid var(--border);">
+                <div style="color:var(--text-muted); font-size:12px; margin-bottom:8px;">PHP</div>
+                <div style="font-size:18px; font-weight:600;">–</div>
+            </div>
+            <div class="stat-card" style="background:var(--bg-card); padding:16px; border-radius:6px; border:1px solid var(--border);">
+                <div style="color:var(--text-muted); font-size:12px; margin-bottom:8px;">Speicher</div>
+                <div style="font-size:18px; font-weight:600;">–</div>
+            </div>
+            <div class="stat-card" style="background:var(--bg-card); padding:16px; border-radius:6px; border:1px solid var(--border);">
+                <div style="color:var(--text-muted); font-size:12px; margin-bottom:8px;">DB-Größe</div>
+                <div style="font-size:18px; font-weight:600;">–</div>
+            </div>
+            <div class="stat-card" style="background:var(--bg-card); padding:16px; border-radius:6px; border:1px solid var(--border);">
+                <div style="color:var(--text-muted); font-size:12px; margin-bottom:8px;">REDAXO</div>
+                <div style="font-size:18px; font-weight:600;">–</div>
+            </div>
+        </div>
+        
+        <div class="accordion-section">
+            <div class="accordion-header" onclick="toggleAccordion(this)">
+                <span class="accordion-title">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="2" y1="20" x2="22" y2="20"/></svg>
+                    System-Informationen
+                </span>
+                <span class="accordion-toggle">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><polyline points="15 18 9 12 15 6"/></svg>
+                </span>
+            </div>
+            <div class="accordion-content">
+                <div style="display:grid; grid-template-columns:1fr 1fr; gap:16px;">
+                    <div>
+                        <div style="color:var(--text-muted); font-size:12px; margin-bottom:6px;">PHP Version</div>
+                        <div style="font-weight:500;">–</div>
+                    </div>
+                    <div>
+                        <div style="color:var(--text-muted); font-size:12px; margin-bottom:6px;">Memory Limit</div>
+                        <div style="font-weight:500;">–</div>
+                    </div>
+                    <div>
+                        <div style="color:var(--text-muted); font-size:12px; margin-bottom:6px;">REDAXO Version</div>
+                        <div style="font-weight:500;">–</div>
+                    </div>
+                    <div>
+                        <div style="color:var(--text-muted); font-size:12px; margin-bottom:6px;">Disk Space</div>
+                        <div style="font-weight:500;">–</div>
+                    </div>
+                </div>
+                <p style="margin-top:12px; font-size:12px; color:var(--text-muted);">ℹ️ API-Endpoints erforderlich</p>
+            </div>
+        </div>
+
+        <div class="accordion-section">
+            <div class="accordion-header" onclick="toggleAccordion(this)">
+                <span class="accordion-title">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 13.39a2 2 0 002 1.61h9.72a2 2 0 002-1.61L23 6H6"/></svg>
+                    Addon Status
+                </span>
+                <span class="accordion-toggle">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><polyline points="15 18 9 12 15 6"/></svg>
+                </span>
+            </div>
+            <div class="accordion-content">
+                <div style="color:var(--text-muted); font-size:12px;">
+                    <div style="margin-bottom:12px;">
+                        <span style="color:var(--success);">●</span> Aktive Addons: –
+                    </div>
+                    <div>
+                        <span style="color:var(--text-muted);">○</span> Inaktive Addons: –
+                    </div>
+                </div>
+                <p style="margin-top:12px; font-size:12px; color:var(--text-muted);">ℹ️ API-Endpoints erforderlich</p>
+            </div>
+        </div>
+
+        <div class="accordion-section">
+            <div class="accordion-header" onclick="toggleAccordion(this)">
+                <span class="accordion-title">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="M4 4h16v16H4z"/><circle cx="12" cy="12" r="3"/><line x1="8" y1="8" x2="8" y2="8"/></svg>
+                    Cache & Performance
+                </span>
+                <span class="accordion-toggle">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><polyline points="15 18 9 12 15 6"/></svg>
+                </span>
+            </div>
+            <div class="accordion-content">
+                <div style="display:grid; grid-template-columns:1fr 1fr; gap:16px;">
+                    <div>
+                        <div style="color:var(--text-muted); font-size:12px; margin-bottom:6px;">Cache Größe</div>
+                        <div style="font-weight:500;">–</div>
+                    </div>
+                    <div>
+                        <div style="color:var(--text-muted); font-size:12px; margin-bottom:6px;">Last Rebuild</div>
+                        <div style="font-weight:500;">–</div>
+                    </div>
+                </div>
+                <button class="btn-icon" style="margin-top:12px; width:100%; justify-content:center;" onclick="clearAllCache()">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22"/><path d="M6 7V5a2 2 0 012-2h8a2 2 0 012 2v2"/></svg>
+                    Cache löschen
+                </button>
+                <p style="margin-top:12px; font-size:12px; color:var(--text-muted);">ℹ️ API-Endpoints erforderlich</p>
+            </div>
+        </div>
+
+        <div class="accordion-section">
+            <div class="accordion-header" onclick="toggleAccordion(this)">
+                <span class="accordion-title">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-2h2v2m0-4h-2V7h2v6z"/></svg>
+                    Letzte Fehler
+                </span>
+                <span class="accordion-toggle">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><polyline points="15 18 9 12 15 6"/></svg>
+                </span>
+            </div>
+            <div class="accordion-content">
+                <div style="color:var(--text-muted); font-size:12px;">Keine Fehler in letzten 24h</div>
+                <p style="margin-top:12px; font-size:12px; color:var(--text-muted);">ℹ️ API-Endpoints erforderlich</p>
+            </div>
+        </div>
+        `;
+        container.innerHTML = html;
+    } catch (err) {
+        container.innerHTML = `<div class="empty-state"><p>Fehler: ${escHtml(err.message)}</p></div>`;
+    }
+}
+
+// ==================== ADDON MANAGER ====================
+
+async function loadAddons() {
+    const container = document.getElementById('addonsTable');
+    try {
+        const html = `
+        <div class="accordion-section">
+            <div class="accordion-header" onclick="toggleAccordion(this)">
+                <span class="accordion-title">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 13.39a2 2 0 002 1.61h9.72a2 2 0 002-1.61L23 6H6"/></svg>
+                    Addons
+                </span>
+                <span class="accordion-toggle">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><polyline points="15 18 9 12 15 6"/></svg>
+                </span>
+            </div>
+            <div class="accordion-content">
+                <p style="color:var(--text-muted); font-size:12px;">ℹ️ Addon-Verwaltung ist noch nicht vollständig implementiert.<br>API-Endpoints für Addon-Management sind erforderlich.</p>
+            </div>
+        </div>`;
+        container.innerHTML = html;
+    } catch (err) {
+        container.innerHTML = `<div class="empty-state"><p>Fehler: ${escHtml(err.message)}</p></div>`;
+    }
+}
+
+// ==================== CACHE MANAGEMENT ====================
+
+async function loadCacheStatus() {
+    const container = document.getElementById('cacheStatus');
+    try {
+        const html = `
+        <div class="accordion-section">
+            <div class="accordion-header" onclick="toggleAccordion(this)">
+                <span class="accordion-title">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="M4 4h16v16H4z"/><circle cx="12" cy="12" r="3"/></svg>
+                    Cache-Statistiken
+                </span>
+                <span class="accordion-toggle">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><polyline points="15 18 9 12 15 6"/></svg>
+                </span>
+            </div>
+            <div class="accordion-content">
+                <div style="display:grid; grid-template-columns:1fr 1fr; gap:16px; margin-bottom:16px;">
+                    <div>
+                        <div style="color:var(--text-muted); font-size:12px; margin-bottom:6px;">Cache Größe</div>
+                        <div style="font-weight:500; font-size:18px;">–</div>
+                    </div>
+                    <div>
+                        <div style="color:var(--text-muted); font-size:12px; margin-bottom:6px;">Last Rebuilt</div>
+                        <div style="font-weight:500; font-size:18px;">–</div>
+                    </div>
+                </div>
+                <button class="btn-icon" style="width:100%; justify-content:center; margin-bottom:12px;" onclick="clearAllCache()">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22"/><path d="M6 7V5a2 2 0 012-2h8a2 2 0 012 2v2"/></svg>
+                    Alle Cache-Einträge löschen
+                </button>
+                <p style="margin-top:12px; font-size:12px; color:var(--text-muted);">ℹ️ API-Endpoints erforderlich</p>
+            </div>
+        </div>
+        <div class="accordion-section">
+            <div class="accordion-header" onclick="toggleAccordion(this)">
+                <span class="accordion-title">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="M4 4h16v16H4z"/></svg>
+                    Query Cache
+                </span>
+                <span class="accordion-toggle">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><polyline points="15 18 9 12 15 6"/></svg>
+                </span>
+            </div>
+            <div class="accordion-content">
+                <p style="color:var(--text-muted); font-size:12px;">Status: –</p>
+                <p style="margin-top:12px; font-size:12px; color:var(--text-muted);">ℹ️ API-Endpoints erforderlich</p>
+            </div>
+        </div>`;
+        container.innerHTML = html;
+    } catch (err) {
+        container.innerHTML = `<div class="empty-state"><p>Fehler: ${escHtml(err.message)}</p></div>`;
+    }
+}
+
+async function clearAllCache() {
+    if (!confirm('Alle Caches wirklich löschen?')) return;
+    try {
+        alert('Cache-Clear ist noch nicht implementiert.\nAPI-Endpoint erforderlich.');
+    } catch (err) {
+        alert(`Fehler: ${err.message}`);
+    }
+}
+
+// ==================== ERROR LOG ====================
+
+let allErrorLogs = [];
+
+async function loadErrorLog() {
+    const container = document.getElementById('errorLogTable');
+    try {
+        const html = `
+        <div class="accordion-section">
+            <div class="accordion-header" onclick="toggleAccordion(this)">
+                <span class="accordion-title">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-2h2v2m0-4h-2V7h2v6z"/></svg>
+                    Fehlerlog
+                </span>
+                <span class="accordion-toggle">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><polyline points="15 18 9 12 15 6"/></svg>
+                </span>
+            </div>
+            <div class="accordion-content">
+                <div style="margin-bottom:12px;">
+                    <input type="text" placeholder="Nach Fehler suchen…" id="errorSearchInput" style="padding:8px 12px; border:1px solid var(--border); border-radius:var(--radius-sm); background:var(--bg-input); color:var(--text); width:100%;" oninput="filterErrorLog()">
+                </div>
+                <div id="errorLogContent" style="color:var(--text-muted); font-size:12px;">Keine Fehler gefunden.</div>
+                <div style="display:flex; gap:8px; margin-top:12px;">
+                    <button class="btn-icon" style="flex:1;" onclick="loadErrorLog()">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>
+                        Aktualisieren
+                    </button>
+                    <button class="btn-icon btn-danger" style="flex:1;" onclick="clearErrorLog()">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22"/><path d="M6 7V5a2 2 0 012-2h8a2 2 0 012 2v2"/></svg>
+                        Löschen
+                    </button>
+                </div>
+                <p style="margin-top:12px; font-size:12px; color:var(--text-muted);">ℹ️ API-Endpoints erforderlich</p>
+            </div>
+        </div>`;
+        container.innerHTML = html;
+    } catch (err) {
+        container.innerHTML = `<div class="empty-state"><p>Fehler: ${escHtml(err.message)}</p></div>`;
+    }
+}
+
+function filterErrorLog() {
+    const search = document.getElementById('errorSearchInput')?.value || '';
+    const filtered = allErrorLogs.filter(log => 
+        (log.message && log.message.toLowerCase().includes(search.toLowerCase())) ||
+        (log.file && log.file.toLowerCase().includes(search.toLowerCase()))
+    );
+    renderErrorLog(filtered);
+}
+
+function renderErrorLog(logs) {
+    const container = document.getElementById('errorLogContent');
+    if (!container) return;
+    
+    if (logs.length === 0) {
+        container.innerHTML = '<div style="color:var(--text-muted); font-size:12px;">Keine Fehler gefunden.</div>';
+        return;
+    }
+    
+    const html = `<div style="max-height:400px; overflow-y:auto;">
+        ${logs.map(log => `
+            <div style="padding:8px 0; border-bottom:1px solid var(--border); font-size:12px;">
+                <div style="font-weight:500; color:var(--text);">${escHtml(log.file || '–')}:${log.line || '–'}</div>
+                <div style="color:var(--text-muted); margin-top:2px;">${escHtml(log.message || '–')}</div>
+                <div style="color:var(--text-muted); opacity:0.6; margin-top:2px; font-size:11px;">${escHtml(log.time || '–')}</div>
+            </div>
+        `).join('')}
+    </div>`;
+    container.innerHTML = html;
+}
+
+async function clearErrorLog() {
+    if (!confirm('Fehlerlog wirklich löschen?')) return;
+    try {
+        alert('Error-Log Clear ist noch nicht implementiert.\nAPI-Endpoint erforderlich.');
+    } catch (err) {
+        alert(`Fehler: ${err.message}`);
+    }
+}
+
+</script>
+<script src="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Holt `assets/dashboard/index.html` zurück ins Repository.

Zur Transparenz: das Verzeichnis wurde am 19.02.2026 mit `3f55212` „Delete assets/dashboard directory" absichtlich aus `main` entfernt. Dieser PR macht das rückgängig — auf ausdrücklichen Wunsch, weil die lokal vorhandene Fassung erhebliche Arbeit enthält, die in keinem Commit existierte:

| | Größe | Stand |
|---|---|---|
| letzte getrackte Version | 101.031 Bytes | 19.02.2026 |
| diese Fassung | **285.291 Bytes** | 04.05. |

Sie entstand also nach dem Löschen. Ein eigenes Repository dafür gibt es bei FriendsOfREDAXO nicht.

@skerbis, falls das Entfernen damals einen Grund hatte, den ich nicht sehe — etwa dass das Dashboard woanders weiterlebt —, sag gerne Bescheid; dann gehört es dorthin statt hierher.

Zwei Anmerkungen: die frühere `assets/dashboard/README.md` (3 KB) ist nicht mit zurückgekommen, sie liegt in der Historie unter `3f55212^`. Und die Datei ruft `/api/dashboard/index` auf — einen Endpunkt, den die API nicht bereitstellt.

---
*Dieser Text wurde durch eine KI erstellt.*
